### PR TITLE
check directories one by one and not depend only on config.js

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -2,9 +2,16 @@
 set -e
 
 if [[ "$*" == npm*start* ]]; then
-	if [ ! -e "$GHOST_CONTENT/config.js" ]; then
-		tar -c --one-file-system -C "$GHOST_SOURCE/content" . | tar xC "$GHOST_CONTENT"
+	content_directories=( "apps" "data" "images" "themes" )
 
+	for dir in "${content_directories[@]}"
+	do
+		if [ ! -d "$GHOST_CONTENT/$dir" ]; then
+			tar -c --one-file-system -C "$GHOST_SOURCE/content" $dir | tar xC "$GHOST_CONTENT"
+		fi
+	done
+
+	if [ ! -e "$GHOST_CONTENT/config.js" ]; then
 		sed -r '
 			s/127\.0\.0\.1/0.0.0.0/g;
 			s!path.join\(__dirname, (.)/content!path.join(process.env.GHOST_CONTENT, \1!g;


### PR DESCRIPTION
As mentioned in https://github.com/docker-library/ghost/pull/5 this change introduces a less radical init process checking and gives you the opportunity to inject your own `config.js` from a data-only container, which should be responsible for holding the state. Otherwise it would not be possible to upgrade the image the container is running on without losing your current state.

This solution still has problems because of the way the container start is handled in general.

The `config.example.js` does not include the `paths` attribute for the production environment and so it is not "fixed" in the way the development environment is with the `sed` command in `docker-entrypoint.sh`

That's why the container start fails when giving `NODE_ENV=production`.
If you put a correct `config.js` in a container from which you get the volumes **before** the first start, the container crashes because the subfolders of the `GHOST_CONTENT` dir were not initialised. This is because a `config.js` was found and the init phase is totally skipped.

This is fixed in this PR.

Anyway you have to pay attention to also "fix" the paths for other environments manually because the automatism via `sed` is only run when als the `config.js` is initialsed automatically which again leads to the production environment problem.

So that's all a bit hacky because the original `config.example.js` is incomplete and needs manual adjustment to work in production.