### PR TITLE
Clearly link to the hub page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # About this Repo
 
-This is the Git repo of the official Docker image for [ghost](https://registry.hub.docker.com/_/ghost/). See the
-Hub page for the full readme on how to use the Docker image and for information
+This is the Git repo of the official Docker image for ghost. See [the Ghost
+Hub page](https://registry.hub.docker.com/_/ghost/) for the full readme on how to use the Docker image and for information
 regarding contributing and issues.
 
 The full readme is generated over in [docker-library/docs](https://github.com/docker-library/docs),


### PR DESCRIPTION
Linking the word ghost is ambiguous. The readme says to go read the hub page, so it's nice and friendly if it is extremely clear how to find that hub page. I was confused by it for a second or two (ok, I was dumb enough to Google the hub page rather than checking the ghost link). Your mileage may vary.