### PR TITLE
Ensure casper theme is always in content directory

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -10,6 +10,12 @@ if [[ "$*" == npm*start* ]]; then
 		fi
 	done
 
+  if [ ! -d "$GHOST_CONTENT/themes/casper" ]; then
+    casperDir="$GHOST_CONTENT/themes/casper"
+    mkdir -p "$casperDir"
+    tar -c --one-file-system -C "$GHOST_SOURCE/content/themes/casper" . | tar xC "$casperDir"
+  fi
+
 	if [ ! -e "$GHOST_CONTENT/config.js" ]; then
 		sed -r '
 			s/127\.0\.0\.1/0.0.0.0/g;


### PR DESCRIPTION
When working on an individual theme, simply mounting the `/var/lib/ghost/themes/$THEME_NAME` directory will not suffice. Casper needs to be in this directory for Ghost to start so it only makes sense that it is guaranteed to be there. 