### PR TITLE
Bumped version used in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ RUN set -x \
 ENV GHOST_SOURCE /usr/src/ghost
 WORKDIR $GHOST_SOURCE
 
-ENV GHOST_VERSION 0.8.0
+ENV GHOST_VERSION 0.9.0
 
 RUN buildDeps=' \
 		gcc \


### PR DESCRIPTION
Bumped up the version in the Dockerfile up to 0.9.0. Not sure if this is completely correct, but it seems that this is all that is needed to ensure that the official docker image can be updated to the latest.

This should fix #38 