### PR TITLE
fix a syntax bug

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -14,7 +14,7 @@ if [[ "$*" == npm*start* ]]; then
 	if [ ! -e "$GHOST_CONTENT/config.js" ]; then
 		sed -r '
 			s/127\.0\.0\.1/0.0.0.0/g;
-			s!path.join\(__dirname, (.)/content!path.join(process.env.GHOST_CONTENT, \1!g;
+			s!path.join(__dirname, \(.\)/content!path.join(process.env.GHOST_CONTENT, \1!g;
 		' "$GHOST_SOURCE/config.example.js" > "$GHOST_CONTENT/config.js"
 	fi
 


### PR DESCRIPTION
When I used this image, the path.join in the config was not replaced by GHOST_CONTENT. So I think there is a mistake in docker-entrypoint.sh. Thank you.  