### PR TITLE
Allow arbitrary --user values

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,8 @@
 # https://github.com/nodejs/LTS
 FROM node:4-slim
 
+RUN groupadd user && useradd --create-home --home-dir /home/user -g user user
+
 # grab gosu for easy step-down from root
 ENV GOSU_VERSION 1.7
 RUN set -x \
@@ -36,7 +38,12 @@ RUN buildDeps=' \
 	&& rm -rf /tmp/npm*
 
 ENV GHOST_CONTENT /var/lib/ghost
-RUN mkdir -p "$GHOST_CONTENT"
+RUN mkdir -p "$GHOST_CONTENT" \
+	&& chown -R user:user "$GHOST_CONTENT" \
+# Ghost expects "config.js" to be in $GHOST_SOURCE, but it's more useful for
+# image users to manage that as part of their $GHOST_CONTENT volume, so we
+# symlink.
+	&& ln -s "$GHOST_CONTENT/config.js" "$GHOST_SOURCE/config.js"
 VOLUME $GHOST_CONTENT
 
 COPY docker-entrypoint.sh /entrypoint.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,6 @@
 # https://github.com/nodejs/LTS
 FROM node:4-slim
 
-RUN groupadd user && useradd --create-home --home-dir /home/user -g user user
-
 # grab gosu for easy step-down from root
 ENV GOSU_VERSION 1.7
 RUN set -x \
@@ -38,7 +36,7 @@ RUN buildDeps=' \
 	&& rm -rf /tmp/npm*
 
 ENV GHOST_CONTENT /var/lib/ghost
-RUN mkdir -p "$GHOST_CONTENT" && chown -R user:user "$GHOST_CONTENT"
+RUN mkdir -p "$GHOST_CONTENT"
 VOLUME $GHOST_CONTENT
 
 COPY docker-entrypoint.sh /entrypoint.sh

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -20,7 +20,12 @@ if [[ "$*" == npm*start* ]]; then
 
 	ln -sf "$GHOST_CONTENT/config.js" "$GHOST_SOURCE/config.js"
 
-	chown -R user "$GHOST_CONTENT"
+        PUID=${PUID:-1001}
+        PGID=${PGID:-1001}
+        groupadd -o -g "$PGID" user
+        useradd --create-home --home-dir /home/user -g user -o -u "$PUID" user
+
+	chown -R user:user "$GHOST_CONTENT"
 
 	set -- gosu user "$@"
 fi


### PR DESCRIPTION
Closes #53 (carried)

This is implemented in the same way we've supported arbitrary values for `docker run --user` in many other images.

See also docker-library/rabbitmq#60, docker-library/cassandra#48, docker-library/mongo#81, docker-library/redis#48, docker-library/mysql#161, and docker-library/mariadb#59, https://github.com/docker-library/percona/pull/21.