### PR TITLE
Updates for Ghost 1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ services: docker
 env:
   - VERSION=0.11 VARIANT=debian
   - VERSION=0.11 VARIANT=alpine
+  - VERSION=1.0 VARIANT=debian
+  - VERSION=1.0 VARIANT=alpine
 
 install:
   - git clone https://github.com/docker-library/official-images.git ~/official-images

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,10 @@ language: bash
 services: docker
 
 env:
-  - VERSION=0.11 VARIANT=debian
-  - VERSION=0.11 VARIANT=alpine
   - VERSION=1.0 VARIANT=debian
   - VERSION=1.0 VARIANT=alpine
+  - VERSION=0.11 VARIANT=debian
+  - VERSION=0.11 VARIANT=alpine
 
 install:
   - git clone https://github.com/docker-library/official-images.git ~/official-images

--- a/0.11/alpine/Dockerfile
+++ b/0.11/alpine/Dockerfile
@@ -1,6 +1,6 @@
-# http://support.ghost.org/supported-node-versions/
+# https://docs.ghost.org/docs/supported-node-versions/
 # https://github.com/nodejs/LTS
-FROM node:4-alpine
+FROM node:6-alpine
 
 # grab su-exec for easy step-down from root
 RUN apk add --no-cache 'su-exec>=0.2'

--- a/0.11/debian/Dockerfile
+++ b/0.11/debian/Dockerfile
@@ -1,6 +1,6 @@
-# http://support.ghost.org/supported-node-versions/
+# https://docs.ghost.org/supported-node-versions/
 # https://github.com/nodejs/LTS
-FROM node:4-slim
+FROM node:6-slim
 
 RUN groupadd user && useradd --create-home --home-dir /home/user -g user user
 

--- a/1.0/alpine/Dockerfile
+++ b/1.0/alpine/Dockerfile
@@ -1,0 +1,35 @@
+# https://docs.ghost.org/supported-node-versions/
+# https://github.com/nodejs/LTS
+FROM node:6-alpine
+
+# grab su-exec for easy step-down from root
+RUN apk add --no-cache 'su-exec>=0.2'
+
+RUN apk add --no-cache \
+# add "bash" for "[["
+		bash
+
+ENV NPM_CONFIG_LOGLEVEL warn
+ENV NODE_ENV production
+ENV GHOST_CLI_VERSION 1.0.0
+ENV GHOST_VERSION 1.0.2
+
+RUN npm i -g "ghost-cli@$GHOST_CLI_VERSION" knex-migrator@latest
+
+ENV GHOST_INSTALL /var/lib/ghost
+ENV GHOST_CONTENT /var/lib/ghost/content
+
+RUN ghost install "$GHOST_VERSION" --db sqlite3 --no-prompt --no-stack --no-setup --dir "$GHOST_INSTALL" \
+        # Tell Ghost to listen on all ips and not prompt for additional configuration
+        && cd "$GHOST_INSTALL" \
+        && ghost config --ip 0.0.0.0 --port 2368 --no-prompt --db sqlite3 --url http://localhost:2368 \ 
+        && chown -R node:node "$GHOST_INSTALL"
+
+WORKDIR $GHOST_INSTALL
+VOLUME $GHOST_CONTENT
+
+COPY docker-entrypoint.sh /usr/local/bin
+ENTRYPOINT ["docker-entrypoint.sh"]
+
+EXPOSE 2368
+CMD ["node", "current/index.js"]

--- a/1.0/alpine/Dockerfile
+++ b/1.0/alpine/Dockerfile
@@ -14,16 +14,26 @@ ENV NODE_ENV production
 ENV GHOST_CLI_VERSION 1.0.0
 ENV GHOST_VERSION 1.0.2
 
-RUN npm i -g "ghost-cli@$GHOST_CLI_VERSION" knex-migrator@latest
+RUN npm install -g "ghost-cli@$GHOST_CLI_VERSION" knex-migrator@latest
 
 ENV GHOST_INSTALL /var/lib/ghost
 ENV GHOST_CONTENT /var/lib/ghost/content
 
-RUN ghost install "$GHOST_VERSION" --db sqlite3 --no-prompt --no-stack --no-setup --dir "$GHOST_INSTALL" \
-        # Tell Ghost to listen on all ips and not prompt for additional configuration
-        && cd "$GHOST_INSTALL" \
-        && ghost config --ip 0.0.0.0 --port 2368 --no-prompt --db sqlite3 --url http://localhost:2368 \ 
-        && chown -R node:node "$GHOST_INSTALL"
+RUN set -ex; \
+	mkdir -p "$GHOST_INSTALL"; \
+	chown node:node "$GHOST_INSTALL"; \
+	\
+	su-exec node ghost install "$GHOST_VERSION" --db sqlite3 --no-prompt --no-stack --no-setup --dir "$GHOST_INSTALL"; \
+	\
+# Tell Ghost to listen on all ips and not prompt for additional configuration
+	cd "$GHOST_INSTALL"; \
+	su-exec node ghost config --ip 0.0.0.0 --port 2368 --no-prompt --db sqlite3 --url http://localhost:2368 --dbpath "$GHOST_CONTENT/data/ghost.db"; \
+	su-exec node ghost config paths.contentPath "$GHOST_CONTENT"; \
+	\
+# need to save initial content for pre-seeding empty volumes
+	mv "$GHOST_CONTENT" "$GHOST_INSTALL/content.orig"; \
+	mkdir -p "$GHOST_CONTENT"; \
+	chown node:node "$GHOST_CONTENT"
 
 WORKDIR $GHOST_INSTALL
 VOLUME $GHOST_CONTENT

--- a/1.0/alpine/docker-entrypoint.sh
+++ b/1.0/alpine/docker-entrypoint.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -e
+
+# allow the container to be started with `--user`
+if [[ "$*" == node*current/index.js* ]] && [ "$(id -u)" = '0' ]; then
+	chown -R node "$GHOST_INSTALL"
+	exec su-exec node "$BASH_SOURCE" "$@"
+fi
+
+if [[ "$*" == node*current/index.js* ]]; then
+	knex-migrator-migrate --init --mgpath "$GHOST_INSTALL/current"
+fi
+
+exec "$@"

--- a/1.0/alpine/docker-entrypoint.sh
+++ b/1.0/alpine/docker-entrypoint.sh
@@ -3,11 +3,21 @@ set -e
 
 # allow the container to be started with `--user`
 if [[ "$*" == node*current/index.js* ]] && [ "$(id -u)" = '0' ]; then
-	chown -R node "$GHOST_INSTALL"
+	chown -R node "$GHOST_CONTENT"
 	exec su-exec node "$BASH_SOURCE" "$@"
 fi
 
 if [[ "$*" == node*current/index.js* ]]; then
+	baseDir="$GHOST_INSTALL/content.orig"
+	for src in "$baseDir"/*/ "$baseDir"/themes/*; do
+		src="${src%/}"
+		target="$GHOST_CONTENT/${src#$baseDir/}"
+		mkdir -p "$(dirname "$target")"
+		if [ ! -e "$target" ]; then
+			tar -cC "$(dirname "$src")" "$(basename "$src")" | tar -xC "$(dirname "$target")"
+		fi
+	done
+
 	knex-migrator-migrate --init --mgpath "$GHOST_INSTALL/current"
 fi
 

--- a/1.0/debian/Dockerfile
+++ b/1.0/debian/Dockerfile
@@ -1,0 +1,42 @@
+# https://docs.ghost.org/supported-node-versions/
+# https://github.com/nodejs/LTS
+FROM node:6-slim
+
+RUN groupadd user && useradd --create-home --home-dir /home/user -g user user
+
+# grab gosu for easy step-down from root
+ENV GOSU_VERSION 1.7
+RUN set -x \
+	&& wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$(dpkg --print-architecture)" \
+	&& wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$(dpkg --print-architecture).asc" \
+	&& export GNUPGHOME="$(mktemp -d)" \
+	&& gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
+	&& gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu \
+	&& rm -r "$GNUPGHOME" /usr/local/bin/gosu.asc \
+	&& chmod +x /usr/local/bin/gosu \
+	&& gosu nobody true
+
+ENV NPM_CONFIG_LOGLEVEL warn
+ENV NODE_ENV production
+ENV GHOST_CLI_VERSION 1.0.0
+ENV GHOST_VERSION 1.0.2
+
+RUN npm i -g "ghost-cli@$GHOST_CLI_VERSION" knex-migrator@latest
+
+ENV GHOST_INSTALL /var/lib/ghost
+ENV GHOST_CONTENT /var/lib/ghost/content
+
+RUN ghost install "$GHOST_VERSION" --db sqlite3 --no-prompt --no-stack --no-setup --dir "$GHOST_INSTALL" \
+        # Tell Ghost to listen on all ips and not prompt for additional configuration
+        && cd "$GHOST_INSTALL" \
+        && ghost config --ip 0.0.0.0 --port 2368 --no-prompt --db sqlite3 --url http://localhost:2368 \ 
+        && chown -R user:user "$GHOST_INSTALL"
+
+WORKDIR $GHOST_INSTALL
+VOLUME $GHOST_CONTENT
+
+COPY docker-entrypoint.sh /usr/local/bin
+ENTRYPOINT ["docker-entrypoint.sh"]
+
+EXPOSE 2368
+CMD ["node", "current/index.js"]

--- a/1.0/debian/Dockerfile
+++ b/1.0/debian/Dockerfile
@@ -2,8 +2,6 @@
 # https://github.com/nodejs/LTS
 FROM node:6-slim
 
-RUN groupadd user && useradd --create-home --home-dir /home/user -g user user
-
 # grab gosu for easy step-down from root
 ENV GOSU_VERSION 1.7
 RUN set -x \
@@ -21,16 +19,26 @@ ENV NODE_ENV production
 ENV GHOST_CLI_VERSION 1.0.0
 ENV GHOST_VERSION 1.0.2
 
-RUN npm i -g "ghost-cli@$GHOST_CLI_VERSION" knex-migrator@latest
+RUN npm install -g "ghost-cli@$GHOST_CLI_VERSION" knex-migrator@latest
 
 ENV GHOST_INSTALL /var/lib/ghost
 ENV GHOST_CONTENT /var/lib/ghost/content
 
-RUN ghost install "$GHOST_VERSION" --db sqlite3 --no-prompt --no-stack --no-setup --dir "$GHOST_INSTALL" \
-        # Tell Ghost to listen on all ips and not prompt for additional configuration
-        && cd "$GHOST_INSTALL" \
-        && ghost config --ip 0.0.0.0 --port 2368 --no-prompt --db sqlite3 --url http://localhost:2368 \ 
-        && chown -R user:user "$GHOST_INSTALL"
+RUN set -ex; \
+	mkdir -p "$GHOST_INSTALL"; \
+	chown node:node "$GHOST_INSTALL"; \
+	\
+	su-exec node ghost install "$GHOST_VERSION" --db sqlite3 --no-prompt --no-stack --no-setup --dir "$GHOST_INSTALL"; \
+	\
+# Tell Ghost to listen on all ips and not prompt for additional configuration
+	cd "$GHOST_INSTALL"; \
+	su-exec node ghost config --ip 0.0.0.0 --port 2368 --no-prompt --db sqlite3 --url http://localhost:2368 --dbpath "$GHOST_CONTENT/data/ghost.db"; \
+	su-exec node ghost config paths.contentPath "$GHOST_CONTENT"; \
+	\
+# need to save initial content for pre-seeding empty volumes
+	mv "$GHOST_CONTENT" "$GHOST_INSTALL/content.orig"; \
+	mkdir -p "$GHOST_CONTENT"; \
+	chown node:node "$GHOST_CONTENT"
 
 WORKDIR $GHOST_INSTALL
 VOLUME $GHOST_CONTENT

--- a/1.0/debian/Dockerfile
+++ b/1.0/debian/Dockerfile
@@ -28,12 +28,12 @@ RUN set -ex; \
 	mkdir -p "$GHOST_INSTALL"; \
 	chown node:node "$GHOST_INSTALL"; \
 	\
-	su-exec node ghost install "$GHOST_VERSION" --db sqlite3 --no-prompt --no-stack --no-setup --dir "$GHOST_INSTALL"; \
+	gosu node ghost install "$GHOST_VERSION" --db sqlite3 --no-prompt --no-stack --no-setup --dir "$GHOST_INSTALL"; \
 	\
 # Tell Ghost to listen on all ips and not prompt for additional configuration
 	cd "$GHOST_INSTALL"; \
-	su-exec node ghost config --ip 0.0.0.0 --port 2368 --no-prompt --db sqlite3 --url http://localhost:2368 --dbpath "$GHOST_CONTENT/data/ghost.db"; \
-	su-exec node ghost config paths.contentPath "$GHOST_CONTENT"; \
+	gosu node ghost config --ip 0.0.0.0 --port 2368 --no-prompt --db sqlite3 --url http://localhost:2368 --dbpath "$GHOST_CONTENT/data/ghost.db"; \
+	gosu node ghost config paths.contentPath "$GHOST_CONTENT"; \
 	\
 # need to save initial content for pre-seeding empty volumes
 	mv "$GHOST_CONTENT" "$GHOST_INSTALL/content.orig"; \

--- a/1.0/debian/docker-entrypoint.sh
+++ b/1.0/debian/docker-entrypoint.sh
@@ -3,11 +3,21 @@ set -e
 
 # allow the container to be started with `--user`
 if [[ "$*" == node*current/index.js* ]] && [ "$(id -u)" = '0' ]; then
-	chown -R user "$GHOST_INSTALL"
-	exec gosu user "$BASH_SOURCE" "$@"
+	chown -R node "$GHOST_CONTENT"
+	exec gosu node "$BASH_SOURCE" "$@"
 fi
 
 if [[ "$*" == node*current/index.js* ]]; then
+	baseDir="$GHOST_INSTALL/content.orig"
+	for src in "$baseDir"/*/ "$baseDir"/themes/*; do
+		src="${src%/}"
+		target="$GHOST_CONTENT/${src#$baseDir/}"
+		mkdir -p "$(dirname "$target")"
+		if [ ! -e "$target" ]; then
+			tar -cC "$(dirname "$src")" "$(basename "$src")" | tar -xC "$(dirname "$target")"
+		fi
+	done
+
 	knex-migrator-migrate --init --mgpath "$GHOST_INSTALL/current"
 fi
 

--- a/1.0/debian/docker-entrypoint.sh
+++ b/1.0/debian/docker-entrypoint.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -e
+
+# allow the container to be started with `--user`
+if [[ "$*" == node*current/index.js* ]] && [ "$(id -u)" = '0' ]; then
+	chown -R user "$GHOST_INSTALL"
+	exec gosu user "$BASH_SOURCE" "$@"
+fi
+
+if [[ "$*" == node*current/index.js* ]]; then
+	knex-migrator-migrate --init --mgpath "$GHOST_INSTALL/current"
+fi
+
+exec "$@"

--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -2,7 +2,8 @@
 set -eu
 
 declare -A aliases=(
-	[0.11]='0 latest'
+	[1.0]='1 latest'
+	[0.11]='0'
 )
 defaultVariant='debian'
 


### PR DESCRIPTION
This PR will do a couple of things:

- [x] Update the base node version of Ghost 0.11.x to 6 as per the [supported node version docs](https://docs.ghost.org/v0.11.9/docs/supported-node-versions)
- [x] Add 1.0 docker configs
- [x] update the stackbrew file (may need some help w/that)