### PR TITLE
Add new releases of ghost from this past week

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: bash
 services: docker
 
 env:
+  - VERSION=1.5 VARIANT=debian
+  - VERSION=1.5 VARIANT=alpine
   - VERSION=1.4 VARIANT=debian
   - VERSION=1.4 VARIANT=alpine
   - VERSION=1.3 VARIANT=debian

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: bash
 services: docker
 
 env:
+  - VERSION=1.4 VARIANT=debian
+  - VERSION=1.4 VARIANT=alpine
   - VERSION=1.3 VARIANT=debian
   - VERSION=1.3 VARIANT=alpine
   - VERSION=1.2 VARIANT=debian

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,12 @@ language: bash
 services: docker
 
 env:
+  - VERSION=1.3 VARIANT=debian
+  - VERSION=1.3 VARIANT=alpine
+  - VERSION=1.2 VARIANT=debian
+  - VERSION=1.2 VARIANT=alpine
+  - VERSION=1.1 VARIANT=debian
+  - VERSION=1.1 VARIANT=alpine
   - VERSION=1.0 VARIANT=debian
   - VERSION=1.0 VARIANT=alpine
   - VERSION=0.11 VARIANT=debian

--- a/1.0/alpine/Dockerfile
+++ b/1.0/alpine/Dockerfile
@@ -11,7 +11,7 @@ RUN apk add --no-cache \
 
 ENV NPM_CONFIG_LOGLEVEL warn
 ENV NODE_ENV production
-ENV GHOST_CLI_VERSION 1.0.0
+ENV GHOST_CLI_VERSION 1.0.3
 ENV GHOST_VERSION 1.0.2
 
 RUN npm install -g "ghost-cli@$GHOST_CLI_VERSION" knex-migrator@latest

--- a/1.0/debian/Dockerfile
+++ b/1.0/debian/Dockerfile
@@ -16,7 +16,7 @@ RUN set -x \
 
 ENV NPM_CONFIG_LOGLEVEL warn
 ENV NODE_ENV production
-ENV GHOST_CLI_VERSION 1.0.0
+ENV GHOST_CLI_VERSION 1.0.3
 ENV GHOST_VERSION 1.0.2
 
 RUN npm install -g "ghost-cli@$GHOST_CLI_VERSION" knex-migrator@latest

--- a/1.1/alpine/Dockerfile
+++ b/1.1/alpine/Dockerfile
@@ -1,0 +1,45 @@
+# https://docs.ghost.org/supported-node-versions/
+# https://github.com/nodejs/LTS
+FROM node:6-alpine
+
+# grab su-exec for easy step-down from root
+RUN apk add --no-cache 'su-exec>=0.2'
+
+RUN apk add --no-cache \
+# add "bash" for "[["
+		bash
+
+ENV NPM_CONFIG_LOGLEVEL warn
+ENV NODE_ENV production
+ENV GHOST_CLI_VERSION 1.0.0
+ENV GHOST_VERSION 1.1.0
+
+RUN npm install -g "ghost-cli@$GHOST_CLI_VERSION" knex-migrator@latest
+
+ENV GHOST_INSTALL /var/lib/ghost
+ENV GHOST_CONTENT /var/lib/ghost/content
+
+RUN set -ex; \
+	mkdir -p "$GHOST_INSTALL"; \
+	chown node:node "$GHOST_INSTALL"; \
+	\
+	su-exec node ghost install "$GHOST_VERSION" --db sqlite3 --no-prompt --no-stack --no-setup --dir "$GHOST_INSTALL"; \
+	\
+# Tell Ghost to listen on all ips and not prompt for additional configuration
+	cd "$GHOST_INSTALL"; \
+	su-exec node ghost config --ip 0.0.0.0 --port 2368 --no-prompt --db sqlite3 --url http://localhost:2368 --dbpath "$GHOST_CONTENT/data/ghost.db"; \
+	su-exec node ghost config paths.contentPath "$GHOST_CONTENT"; \
+	\
+# need to save initial content for pre-seeding empty volumes
+	mv "$GHOST_CONTENT" "$GHOST_INSTALL/content.orig"; \
+	mkdir -p "$GHOST_CONTENT"; \
+	chown node:node "$GHOST_CONTENT"
+
+WORKDIR $GHOST_INSTALL
+VOLUME $GHOST_CONTENT
+
+COPY docker-entrypoint.sh /usr/local/bin
+ENTRYPOINT ["docker-entrypoint.sh"]
+
+EXPOSE 2368
+CMD ["node", "current/index.js"]

--- a/1.1/alpine/Dockerfile
+++ b/1.1/alpine/Dockerfile
@@ -11,7 +11,7 @@ RUN apk add --no-cache \
 
 ENV NPM_CONFIG_LOGLEVEL warn
 ENV NODE_ENV production
-ENV GHOST_CLI_VERSION 1.0.0
+ENV GHOST_CLI_VERSION 1.0.3
 ENV GHOST_VERSION 1.1.0
 
 RUN npm install -g "ghost-cli@$GHOST_CLI_VERSION" knex-migrator@latest

--- a/1.1/alpine/docker-entrypoint.sh
+++ b/1.1/alpine/docker-entrypoint.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+set -e
+
+# allow the container to be started with `--user`
+if [[ "$*" == node*current/index.js* ]] && [ "$(id -u)" = '0' ]; then
+	chown -R node "$GHOST_CONTENT"
+	exec su-exec node "$BASH_SOURCE" "$@"
+fi
+
+if [[ "$*" == node*current/index.js* ]]; then
+	baseDir="$GHOST_INSTALL/content.orig"
+	for src in "$baseDir"/*/ "$baseDir"/themes/*; do
+		src="${src%/}"
+		target="$GHOST_CONTENT/${src#$baseDir/}"
+		mkdir -p "$(dirname "$target")"
+		if [ ! -e "$target" ]; then
+			tar -cC "$(dirname "$src")" "$(basename "$src")" | tar -xC "$(dirname "$target")"
+		fi
+	done
+
+	knex-migrator-migrate --init --mgpath "$GHOST_INSTALL/current"
+fi
+
+exec "$@"

--- a/1.1/debian/Dockerfile
+++ b/1.1/debian/Dockerfile
@@ -1,0 +1,50 @@
+# https://docs.ghost.org/supported-node-versions/
+# https://github.com/nodejs/LTS
+FROM node:6-slim
+
+# grab gosu for easy step-down from root
+ENV GOSU_VERSION 1.7
+RUN set -x \
+	&& wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$(dpkg --print-architecture)" \
+	&& wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$(dpkg --print-architecture).asc" \
+	&& export GNUPGHOME="$(mktemp -d)" \
+	&& gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
+	&& gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu \
+	&& rm -r "$GNUPGHOME" /usr/local/bin/gosu.asc \
+	&& chmod +x /usr/local/bin/gosu \
+	&& gosu nobody true
+
+ENV NPM_CONFIG_LOGLEVEL warn
+ENV NODE_ENV production
+ENV GHOST_CLI_VERSION 1.0.0
+ENV GHOST_VERSION 1.1.0
+
+RUN npm install -g "ghost-cli@$GHOST_CLI_VERSION" knex-migrator@latest
+
+ENV GHOST_INSTALL /var/lib/ghost
+ENV GHOST_CONTENT /var/lib/ghost/content
+
+RUN set -ex; \
+	mkdir -p "$GHOST_INSTALL"; \
+	chown node:node "$GHOST_INSTALL"; \
+	\
+	gosu node ghost install "$GHOST_VERSION" --db sqlite3 --no-prompt --no-stack --no-setup --dir "$GHOST_INSTALL"; \
+	\
+# Tell Ghost to listen on all ips and not prompt for additional configuration
+	cd "$GHOST_INSTALL"; \
+	gosu node ghost config --ip 0.0.0.0 --port 2368 --no-prompt --db sqlite3 --url http://localhost:2368 --dbpath "$GHOST_CONTENT/data/ghost.db"; \
+	gosu node ghost config paths.contentPath "$GHOST_CONTENT"; \
+	\
+# need to save initial content for pre-seeding empty volumes
+	mv "$GHOST_CONTENT" "$GHOST_INSTALL/content.orig"; \
+	mkdir -p "$GHOST_CONTENT"; \
+	chown node:node "$GHOST_CONTENT"
+
+WORKDIR $GHOST_INSTALL
+VOLUME $GHOST_CONTENT
+
+COPY docker-entrypoint.sh /usr/local/bin
+ENTRYPOINT ["docker-entrypoint.sh"]
+
+EXPOSE 2368
+CMD ["node", "current/index.js"]

--- a/1.1/debian/Dockerfile
+++ b/1.1/debian/Dockerfile
@@ -16,7 +16,7 @@ RUN set -x \
 
 ENV NPM_CONFIG_LOGLEVEL warn
 ENV NODE_ENV production
-ENV GHOST_CLI_VERSION 1.0.0
+ENV GHOST_CLI_VERSION 1.0.3
 ENV GHOST_VERSION 1.1.0
 
 RUN npm install -g "ghost-cli@$GHOST_CLI_VERSION" knex-migrator@latest

--- a/1.1/debian/docker-entrypoint.sh
+++ b/1.1/debian/docker-entrypoint.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+set -e
+
+# allow the container to be started with `--user`
+if [[ "$*" == node*current/index.js* ]] && [ "$(id -u)" = '0' ]; then
+	chown -R node "$GHOST_CONTENT"
+	exec gosu node "$BASH_SOURCE" "$@"
+fi
+
+if [[ "$*" == node*current/index.js* ]]; then
+	baseDir="$GHOST_INSTALL/content.orig"
+	for src in "$baseDir"/*/ "$baseDir"/themes/*; do
+		src="${src%/}"
+		target="$GHOST_CONTENT/${src#$baseDir/}"
+		mkdir -p "$(dirname "$target")"
+		if [ ! -e "$target" ]; then
+			tar -cC "$(dirname "$src")" "$(basename "$src")" | tar -xC "$(dirname "$target")"
+		fi
+	done
+
+	knex-migrator-migrate --init --mgpath "$GHOST_INSTALL/current"
+fi
+
+exec "$@"

--- a/1.2/alpine/Dockerfile
+++ b/1.2/alpine/Dockerfile
@@ -1,0 +1,45 @@
+# https://docs.ghost.org/supported-node-versions/
+# https://github.com/nodejs/LTS
+FROM node:6-alpine
+
+# grab su-exec for easy step-down from root
+RUN apk add --no-cache 'su-exec>=0.2'
+
+RUN apk add --no-cache \
+# add "bash" for "[["
+		bash
+
+ENV NPM_CONFIG_LOGLEVEL warn
+ENV NODE_ENV production
+ENV GHOST_CLI_VERSION 1.0.0
+ENV GHOST_VERSION 1.2.0
+
+RUN npm install -g "ghost-cli@$GHOST_CLI_VERSION" knex-migrator@latest
+
+ENV GHOST_INSTALL /var/lib/ghost
+ENV GHOST_CONTENT /var/lib/ghost/content
+
+RUN set -ex; \
+	mkdir -p "$GHOST_INSTALL"; \
+	chown node:node "$GHOST_INSTALL"; \
+	\
+	su-exec node ghost install "$GHOST_VERSION" --db sqlite3 --no-prompt --no-stack --no-setup --dir "$GHOST_INSTALL"; \
+	\
+# Tell Ghost to listen on all ips and not prompt for additional configuration
+	cd "$GHOST_INSTALL"; \
+	su-exec node ghost config --ip 0.0.0.0 --port 2368 --no-prompt --db sqlite3 --url http://localhost:2368 --dbpath "$GHOST_CONTENT/data/ghost.db"; \
+	su-exec node ghost config paths.contentPath "$GHOST_CONTENT"; \
+	\
+# need to save initial content for pre-seeding empty volumes
+	mv "$GHOST_CONTENT" "$GHOST_INSTALL/content.orig"; \
+	mkdir -p "$GHOST_CONTENT"; \
+	chown node:node "$GHOST_CONTENT"
+
+WORKDIR $GHOST_INSTALL
+VOLUME $GHOST_CONTENT
+
+COPY docker-entrypoint.sh /usr/local/bin
+ENTRYPOINT ["docker-entrypoint.sh"]
+
+EXPOSE 2368
+CMD ["node", "current/index.js"]

--- a/1.2/alpine/Dockerfile
+++ b/1.2/alpine/Dockerfile
@@ -11,7 +11,7 @@ RUN apk add --no-cache \
 
 ENV NPM_CONFIG_LOGLEVEL warn
 ENV NODE_ENV production
-ENV GHOST_CLI_VERSION 1.0.0
+ENV GHOST_CLI_VERSION 1.0.3
 ENV GHOST_VERSION 1.2.0
 
 RUN npm install -g "ghost-cli@$GHOST_CLI_VERSION" knex-migrator@latest

--- a/1.2/alpine/docker-entrypoint.sh
+++ b/1.2/alpine/docker-entrypoint.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+set -e
+
+# allow the container to be started with `--user`
+if [[ "$*" == node*current/index.js* ]] && [ "$(id -u)" = '0' ]; then
+	chown -R node "$GHOST_CONTENT"
+	exec su-exec node "$BASH_SOURCE" "$@"
+fi
+
+if [[ "$*" == node*current/index.js* ]]; then
+	baseDir="$GHOST_INSTALL/content.orig"
+	for src in "$baseDir"/*/ "$baseDir"/themes/*; do
+		src="${src%/}"
+		target="$GHOST_CONTENT/${src#$baseDir/}"
+		mkdir -p "$(dirname "$target")"
+		if [ ! -e "$target" ]; then
+			tar -cC "$(dirname "$src")" "$(basename "$src")" | tar -xC "$(dirname "$target")"
+		fi
+	done
+
+	knex-migrator-migrate --init --mgpath "$GHOST_INSTALL/current"
+fi
+
+exec "$@"

--- a/1.2/debian/Dockerfile
+++ b/1.2/debian/Dockerfile
@@ -16,7 +16,7 @@ RUN set -x \
 
 ENV NPM_CONFIG_LOGLEVEL warn
 ENV NODE_ENV production
-ENV GHOST_CLI_VERSION 1.0.0
+ENV GHOST_CLI_VERSION 1.0.3
 ENV GHOST_VERSION 1.2.0
 
 RUN npm install -g "ghost-cli@$GHOST_CLI_VERSION" knex-migrator@latest

--- a/1.2/debian/Dockerfile
+++ b/1.2/debian/Dockerfile
@@ -1,0 +1,50 @@
+# https://docs.ghost.org/supported-node-versions/
+# https://github.com/nodejs/LTS
+FROM node:6-slim
+
+# grab gosu for easy step-down from root
+ENV GOSU_VERSION 1.7
+RUN set -x \
+	&& wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$(dpkg --print-architecture)" \
+	&& wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$(dpkg --print-architecture).asc" \
+	&& export GNUPGHOME="$(mktemp -d)" \
+	&& gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
+	&& gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu \
+	&& rm -r "$GNUPGHOME" /usr/local/bin/gosu.asc \
+	&& chmod +x /usr/local/bin/gosu \
+	&& gosu nobody true
+
+ENV NPM_CONFIG_LOGLEVEL warn
+ENV NODE_ENV production
+ENV GHOST_CLI_VERSION 1.0.0
+ENV GHOST_VERSION 1.2.0
+
+RUN npm install -g "ghost-cli@$GHOST_CLI_VERSION" knex-migrator@latest
+
+ENV GHOST_INSTALL /var/lib/ghost
+ENV GHOST_CONTENT /var/lib/ghost/content
+
+RUN set -ex; \
+	mkdir -p "$GHOST_INSTALL"; \
+	chown node:node "$GHOST_INSTALL"; \
+	\
+	gosu node ghost install "$GHOST_VERSION" --db sqlite3 --no-prompt --no-stack --no-setup --dir "$GHOST_INSTALL"; \
+	\
+# Tell Ghost to listen on all ips and not prompt for additional configuration
+	cd "$GHOST_INSTALL"; \
+	gosu node ghost config --ip 0.0.0.0 --port 2368 --no-prompt --db sqlite3 --url http://localhost:2368 --dbpath "$GHOST_CONTENT/data/ghost.db"; \
+	gosu node ghost config paths.contentPath "$GHOST_CONTENT"; \
+	\
+# need to save initial content for pre-seeding empty volumes
+	mv "$GHOST_CONTENT" "$GHOST_INSTALL/content.orig"; \
+	mkdir -p "$GHOST_CONTENT"; \
+	chown node:node "$GHOST_CONTENT"
+
+WORKDIR $GHOST_INSTALL
+VOLUME $GHOST_CONTENT
+
+COPY docker-entrypoint.sh /usr/local/bin
+ENTRYPOINT ["docker-entrypoint.sh"]
+
+EXPOSE 2368
+CMD ["node", "current/index.js"]

--- a/1.2/debian/docker-entrypoint.sh
+++ b/1.2/debian/docker-entrypoint.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+set -e
+
+# allow the container to be started with `--user`
+if [[ "$*" == node*current/index.js* ]] && [ "$(id -u)" = '0' ]; then
+	chown -R node "$GHOST_CONTENT"
+	exec gosu node "$BASH_SOURCE" "$@"
+fi
+
+if [[ "$*" == node*current/index.js* ]]; then
+	baseDir="$GHOST_INSTALL/content.orig"
+	for src in "$baseDir"/*/ "$baseDir"/themes/*; do
+		src="${src%/}"
+		target="$GHOST_CONTENT/${src#$baseDir/}"
+		mkdir -p "$(dirname "$target")"
+		if [ ! -e "$target" ]; then
+			tar -cC "$(dirname "$src")" "$(basename "$src")" | tar -xC "$(dirname "$target")"
+		fi
+	done
+
+	knex-migrator-migrate --init --mgpath "$GHOST_INSTALL/current"
+fi
+
+exec "$@"

--- a/1.3/alpine/Dockerfile
+++ b/1.3/alpine/Dockerfile
@@ -1,0 +1,45 @@
+# https://docs.ghost.org/supported-node-versions/
+# https://github.com/nodejs/LTS
+FROM node:6-alpine
+
+# grab su-exec for easy step-down from root
+RUN apk add --no-cache 'su-exec>=0.2'
+
+RUN apk add --no-cache \
+# add "bash" for "[["
+		bash
+
+ENV NPM_CONFIG_LOGLEVEL warn
+ENV NODE_ENV production
+ENV GHOST_CLI_VERSION 1.0.3
+ENV GHOST_VERSION 1.3.0
+
+RUN npm install -g "ghost-cli@$GHOST_CLI_VERSION" knex-migrator@latest
+
+ENV GHOST_INSTALL /var/lib/ghost
+ENV GHOST_CONTENT /var/lib/ghost/content
+
+RUN set -ex; \
+	mkdir -p "$GHOST_INSTALL"; \
+	chown node:node "$GHOST_INSTALL"; \
+	\
+	su-exec node ghost install "$GHOST_VERSION" --db sqlite3 --no-prompt --no-stack --no-setup --dir "$GHOST_INSTALL"; \
+	\
+# Tell Ghost to listen on all ips and not prompt for additional configuration
+	cd "$GHOST_INSTALL"; \
+	su-exec node ghost config --ip 0.0.0.0 --port 2368 --no-prompt --db sqlite3 --url http://localhost:2368 --dbpath "$GHOST_CONTENT/data/ghost.db"; \
+	su-exec node ghost config paths.contentPath "$GHOST_CONTENT"; \
+	\
+# need to save initial content for pre-seeding empty volumes
+	mv "$GHOST_CONTENT" "$GHOST_INSTALL/content.orig"; \
+	mkdir -p "$GHOST_CONTENT"; \
+	chown node:node "$GHOST_CONTENT"
+
+WORKDIR $GHOST_INSTALL
+VOLUME $GHOST_CONTENT
+
+COPY docker-entrypoint.sh /usr/local/bin
+ENTRYPOINT ["docker-entrypoint.sh"]
+
+EXPOSE 2368
+CMD ["node", "current/index.js"]

--- a/1.3/alpine/docker-entrypoint.sh
+++ b/1.3/alpine/docker-entrypoint.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+set -e
+
+# allow the container to be started with `--user`
+if [[ "$*" == node*current/index.js* ]] && [ "$(id -u)" = '0' ]; then
+	chown -R node "$GHOST_CONTENT"
+	exec su-exec node "$BASH_SOURCE" "$@"
+fi
+
+if [[ "$*" == node*current/index.js* ]]; then
+	baseDir="$GHOST_INSTALL/content.orig"
+	for src in "$baseDir"/*/ "$baseDir"/themes/*; do
+		src="${src%/}"
+		target="$GHOST_CONTENT/${src#$baseDir/}"
+		mkdir -p "$(dirname "$target")"
+		if [ ! -e "$target" ]; then
+			tar -cC "$(dirname "$src")" "$(basename "$src")" | tar -xC "$(dirname "$target")"
+		fi
+	done
+
+	knex-migrator-migrate --init --mgpath "$GHOST_INSTALL/current"
+fi
+
+exec "$@"

--- a/1.3/debian/Dockerfile
+++ b/1.3/debian/Dockerfile
@@ -1,0 +1,50 @@
+# https://docs.ghost.org/supported-node-versions/
+# https://github.com/nodejs/LTS
+FROM node:6-slim
+
+# grab gosu for easy step-down from root
+ENV GOSU_VERSION 1.7
+RUN set -x \
+	&& wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$(dpkg --print-architecture)" \
+	&& wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$(dpkg --print-architecture).asc" \
+	&& export GNUPGHOME="$(mktemp -d)" \
+	&& gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
+	&& gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu \
+	&& rm -r "$GNUPGHOME" /usr/local/bin/gosu.asc \
+	&& chmod +x /usr/local/bin/gosu \
+	&& gosu nobody true
+
+ENV NPM_CONFIG_LOGLEVEL warn
+ENV NODE_ENV production
+ENV GHOST_CLI_VERSION 1.0.3
+ENV GHOST_VERSION 1.3.0
+
+RUN npm install -g "ghost-cli@$GHOST_CLI_VERSION" knex-migrator@latest
+
+ENV GHOST_INSTALL /var/lib/ghost
+ENV GHOST_CONTENT /var/lib/ghost/content
+
+RUN set -ex; \
+	mkdir -p "$GHOST_INSTALL"; \
+	chown node:node "$GHOST_INSTALL"; \
+	\
+	gosu node ghost install "$GHOST_VERSION" --db sqlite3 --no-prompt --no-stack --no-setup --dir "$GHOST_INSTALL"; \
+	\
+# Tell Ghost to listen on all ips and not prompt for additional configuration
+	cd "$GHOST_INSTALL"; \
+	gosu node ghost config --ip 0.0.0.0 --port 2368 --no-prompt --db sqlite3 --url http://localhost:2368 --dbpath "$GHOST_CONTENT/data/ghost.db"; \
+	gosu node ghost config paths.contentPath "$GHOST_CONTENT"; \
+	\
+# need to save initial content for pre-seeding empty volumes
+	mv "$GHOST_CONTENT" "$GHOST_INSTALL/content.orig"; \
+	mkdir -p "$GHOST_CONTENT"; \
+	chown node:node "$GHOST_CONTENT"
+
+WORKDIR $GHOST_INSTALL
+VOLUME $GHOST_CONTENT
+
+COPY docker-entrypoint.sh /usr/local/bin
+ENTRYPOINT ["docker-entrypoint.sh"]
+
+EXPOSE 2368
+CMD ["node", "current/index.js"]

--- a/1.3/debian/docker-entrypoint.sh
+++ b/1.3/debian/docker-entrypoint.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+set -e
+
+# allow the container to be started with `--user`
+if [[ "$*" == node*current/index.js* ]] && [ "$(id -u)" = '0' ]; then
+	chown -R node "$GHOST_CONTENT"
+	exec gosu node "$BASH_SOURCE" "$@"
+fi
+
+if [[ "$*" == node*current/index.js* ]]; then
+	baseDir="$GHOST_INSTALL/content.orig"
+	for src in "$baseDir"/*/ "$baseDir"/themes/*; do
+		src="${src%/}"
+		target="$GHOST_CONTENT/${src#$baseDir/}"
+		mkdir -p "$(dirname "$target")"
+		if [ ! -e "$target" ]; then
+			tar -cC "$(dirname "$src")" "$(basename "$src")" | tar -xC "$(dirname "$target")"
+		fi
+	done
+
+	knex-migrator-migrate --init --mgpath "$GHOST_INSTALL/current"
+fi
+
+exec "$@"

--- a/1.4/alpine/Dockerfile
+++ b/1.4/alpine/Dockerfile
@@ -1,0 +1,45 @@
+# https://docs.ghost.org/supported-node-versions/
+# https://github.com/nodejs/LTS
+FROM node:6-alpine
+
+# grab su-exec for easy step-down from root
+RUN apk add --no-cache 'su-exec>=0.2'
+
+RUN apk add --no-cache \
+# add "bash" for "[["
+		bash
+
+ENV NPM_CONFIG_LOGLEVEL warn
+ENV NODE_ENV production
+ENV GHOST_CLI_VERSION 1.0.3
+ENV GHOST_VERSION 1.4.0
+
+RUN npm install -g "ghost-cli@$GHOST_CLI_VERSION" knex-migrator@latest
+
+ENV GHOST_INSTALL /var/lib/ghost
+ENV GHOST_CONTENT /var/lib/ghost/content
+
+RUN set -ex; \
+	mkdir -p "$GHOST_INSTALL"; \
+	chown node:node "$GHOST_INSTALL"; \
+	\
+	su-exec node ghost install "$GHOST_VERSION" --db sqlite3 --no-prompt --no-stack --no-setup --dir "$GHOST_INSTALL"; \
+	\
+# Tell Ghost to listen on all ips and not prompt for additional configuration
+	cd "$GHOST_INSTALL"; \
+	su-exec node ghost config --ip 0.0.0.0 --port 2368 --no-prompt --db sqlite3 --url http://localhost:2368 --dbpath "$GHOST_CONTENT/data/ghost.db"; \
+	su-exec node ghost config paths.contentPath "$GHOST_CONTENT"; \
+	\
+# need to save initial content for pre-seeding empty volumes
+	mv "$GHOST_CONTENT" "$GHOST_INSTALL/content.orig"; \
+	mkdir -p "$GHOST_CONTENT"; \
+	chown node:node "$GHOST_CONTENT"
+
+WORKDIR $GHOST_INSTALL
+VOLUME $GHOST_CONTENT
+
+COPY docker-entrypoint.sh /usr/local/bin
+ENTRYPOINT ["docker-entrypoint.sh"]
+
+EXPOSE 2368
+CMD ["node", "current/index.js"]

--- a/1.4/alpine/docker-entrypoint.sh
+++ b/1.4/alpine/docker-entrypoint.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+set -e
+
+# allow the container to be started with `--user`
+if [[ "$*" == node*current/index.js* ]] && [ "$(id -u)" = '0' ]; then
+	chown -R node "$GHOST_CONTENT"
+	exec su-exec node "$BASH_SOURCE" "$@"
+fi
+
+if [[ "$*" == node*current/index.js* ]]; then
+	baseDir="$GHOST_INSTALL/content.orig"
+	for src in "$baseDir"/*/ "$baseDir"/themes/*; do
+		src="${src%/}"
+		target="$GHOST_CONTENT/${src#$baseDir/}"
+		mkdir -p "$(dirname "$target")"
+		if [ ! -e "$target" ]; then
+			tar -cC "$(dirname "$src")" "$(basename "$src")" | tar -xC "$(dirname "$target")"
+		fi
+	done
+
+	knex-migrator-migrate --init --mgpath "$GHOST_INSTALL/current"
+fi
+
+exec "$@"

--- a/1.4/debian/Dockerfile
+++ b/1.4/debian/Dockerfile
@@ -1,0 +1,50 @@
+# https://docs.ghost.org/supported-node-versions/
+# https://github.com/nodejs/LTS
+FROM node:6-slim
+
+# grab gosu for easy step-down from root
+ENV GOSU_VERSION 1.7
+RUN set -x \
+	&& wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$(dpkg --print-architecture)" \
+	&& wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$(dpkg --print-architecture).asc" \
+	&& export GNUPGHOME="$(mktemp -d)" \
+	&& gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
+	&& gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu \
+	&& rm -r "$GNUPGHOME" /usr/local/bin/gosu.asc \
+	&& chmod +x /usr/local/bin/gosu \
+	&& gosu nobody true
+
+ENV NPM_CONFIG_LOGLEVEL warn
+ENV NODE_ENV production
+ENV GHOST_CLI_VERSION 1.0.3
+ENV GHOST_VERSION 1.4.0
+
+RUN npm install -g "ghost-cli@$GHOST_CLI_VERSION" knex-migrator@latest
+
+ENV GHOST_INSTALL /var/lib/ghost
+ENV GHOST_CONTENT /var/lib/ghost/content
+
+RUN set -ex; \
+	mkdir -p "$GHOST_INSTALL"; \
+	chown node:node "$GHOST_INSTALL"; \
+	\
+	gosu node ghost install "$GHOST_VERSION" --db sqlite3 --no-prompt --no-stack --no-setup --dir "$GHOST_INSTALL"; \
+	\
+# Tell Ghost to listen on all ips and not prompt for additional configuration
+	cd "$GHOST_INSTALL"; \
+	gosu node ghost config --ip 0.0.0.0 --port 2368 --no-prompt --db sqlite3 --url http://localhost:2368 --dbpath "$GHOST_CONTENT/data/ghost.db"; \
+	gosu node ghost config paths.contentPath "$GHOST_CONTENT"; \
+	\
+# need to save initial content for pre-seeding empty volumes
+	mv "$GHOST_CONTENT" "$GHOST_INSTALL/content.orig"; \
+	mkdir -p "$GHOST_CONTENT"; \
+	chown node:node "$GHOST_CONTENT"
+
+WORKDIR $GHOST_INSTALL
+VOLUME $GHOST_CONTENT
+
+COPY docker-entrypoint.sh /usr/local/bin
+ENTRYPOINT ["docker-entrypoint.sh"]
+
+EXPOSE 2368
+CMD ["node", "current/index.js"]

--- a/1.4/debian/docker-entrypoint.sh
+++ b/1.4/debian/docker-entrypoint.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+set -e
+
+# allow the container to be started with `--user`
+if [[ "$*" == node*current/index.js* ]] && [ "$(id -u)" = '0' ]; then
+	chown -R node "$GHOST_CONTENT"
+	exec gosu node "$BASH_SOURCE" "$@"
+fi
+
+if [[ "$*" == node*current/index.js* ]]; then
+	baseDir="$GHOST_INSTALL/content.orig"
+	for src in "$baseDir"/*/ "$baseDir"/themes/*; do
+		src="${src%/}"
+		target="$GHOST_CONTENT/${src#$baseDir/}"
+		mkdir -p "$(dirname "$target")"
+		if [ ! -e "$target" ]; then
+			tar -cC "$(dirname "$src")" "$(basename "$src")" | tar -xC "$(dirname "$target")"
+		fi
+	done
+
+	knex-migrator-migrate --init --mgpath "$GHOST_INSTALL/current"
+fi
+
+exec "$@"

--- a/1.5/alpine/Dockerfile
+++ b/1.5/alpine/Dockerfile
@@ -1,0 +1,45 @@
+# https://docs.ghost.org/supported-node-versions/
+# https://github.com/nodejs/LTS
+FROM node:6-alpine
+
+# grab su-exec for easy step-down from root
+RUN apk add --no-cache 'su-exec>=0.2'
+
+RUN apk add --no-cache \
+# add "bash" for "[["
+		bash
+
+ENV NPM_CONFIG_LOGLEVEL warn
+ENV NODE_ENV production
+ENV GHOST_CLI_VERSION 1.0.3
+ENV GHOST_VERSION 1.5.0
+
+RUN npm install -g "ghost-cli@$GHOST_CLI_VERSION" knex-migrator@latest
+
+ENV GHOST_INSTALL /var/lib/ghost
+ENV GHOST_CONTENT /var/lib/ghost/content
+
+RUN set -ex; \
+	mkdir -p "$GHOST_INSTALL"; \
+	chown node:node "$GHOST_INSTALL"; \
+	\
+	su-exec node ghost install "$GHOST_VERSION" --db sqlite3 --no-prompt --no-stack --no-setup --dir "$GHOST_INSTALL"; \
+	\
+# Tell Ghost to listen on all ips and not prompt for additional configuration
+	cd "$GHOST_INSTALL"; \
+	su-exec node ghost config --ip 0.0.0.0 --port 2368 --no-prompt --db sqlite3 --url http://localhost:2368 --dbpath "$GHOST_CONTENT/data/ghost.db"; \
+	su-exec node ghost config paths.contentPath "$GHOST_CONTENT"; \
+	\
+# need to save initial content for pre-seeding empty volumes
+	mv "$GHOST_CONTENT" "$GHOST_INSTALL/content.orig"; \
+	mkdir -p "$GHOST_CONTENT"; \
+	chown node:node "$GHOST_CONTENT"
+
+WORKDIR $GHOST_INSTALL
+VOLUME $GHOST_CONTENT
+
+COPY docker-entrypoint.sh /usr/local/bin
+ENTRYPOINT ["docker-entrypoint.sh"]
+
+EXPOSE 2368
+CMD ["node", "current/index.js"]

--- a/1.5/alpine/docker-entrypoint.sh
+++ b/1.5/alpine/docker-entrypoint.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+set -e
+
+# allow the container to be started with `--user`
+if [[ "$*" == node*current/index.js* ]] && [ "$(id -u)" = '0' ]; then
+	chown -R node "$GHOST_CONTENT"
+	exec su-exec node "$BASH_SOURCE" "$@"
+fi
+
+if [[ "$*" == node*current/index.js* ]]; then
+	baseDir="$GHOST_INSTALL/content.orig"
+	for src in "$baseDir"/*/ "$baseDir"/themes/*; do
+		src="${src%/}"
+		target="$GHOST_CONTENT/${src#$baseDir/}"
+		mkdir -p "$(dirname "$target")"
+		if [ ! -e "$target" ]; then
+			tar -cC "$(dirname "$src")" "$(basename "$src")" | tar -xC "$(dirname "$target")"
+		fi
+	done
+
+	knex-migrator-migrate --init --mgpath "$GHOST_INSTALL/current"
+fi
+
+exec "$@"

--- a/1.5/debian/Dockerfile
+++ b/1.5/debian/Dockerfile
@@ -1,0 +1,50 @@
+# https://docs.ghost.org/supported-node-versions/
+# https://github.com/nodejs/LTS
+FROM node:6-slim
+
+# grab gosu for easy step-down from root
+ENV GOSU_VERSION 1.7
+RUN set -x \
+	&& wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$(dpkg --print-architecture)" \
+	&& wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$(dpkg --print-architecture).asc" \
+	&& export GNUPGHOME="$(mktemp -d)" \
+	&& gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
+	&& gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu \
+	&& rm -r "$GNUPGHOME" /usr/local/bin/gosu.asc \
+	&& chmod +x /usr/local/bin/gosu \
+	&& gosu nobody true
+
+ENV NPM_CONFIG_LOGLEVEL warn
+ENV NODE_ENV production
+ENV GHOST_CLI_VERSION 1.0.3
+ENV GHOST_VERSION 1.5.0
+
+RUN npm install -g "ghost-cli@$GHOST_CLI_VERSION" knex-migrator@latest
+
+ENV GHOST_INSTALL /var/lib/ghost
+ENV GHOST_CONTENT /var/lib/ghost/content
+
+RUN set -ex; \
+	mkdir -p "$GHOST_INSTALL"; \
+	chown node:node "$GHOST_INSTALL"; \
+	\
+	gosu node ghost install "$GHOST_VERSION" --db sqlite3 --no-prompt --no-stack --no-setup --dir "$GHOST_INSTALL"; \
+	\
+# Tell Ghost to listen on all ips and not prompt for additional configuration
+	cd "$GHOST_INSTALL"; \
+	gosu node ghost config --ip 0.0.0.0 --port 2368 --no-prompt --db sqlite3 --url http://localhost:2368 --dbpath "$GHOST_CONTENT/data/ghost.db"; \
+	gosu node ghost config paths.contentPath "$GHOST_CONTENT"; \
+	\
+# need to save initial content for pre-seeding empty volumes
+	mv "$GHOST_CONTENT" "$GHOST_INSTALL/content.orig"; \
+	mkdir -p "$GHOST_CONTENT"; \
+	chown node:node "$GHOST_CONTENT"
+
+WORKDIR $GHOST_INSTALL
+VOLUME $GHOST_CONTENT
+
+COPY docker-entrypoint.sh /usr/local/bin
+ENTRYPOINT ["docker-entrypoint.sh"]
+
+EXPOSE 2368
+CMD ["node", "current/index.js"]

--- a/1.5/debian/docker-entrypoint.sh
+++ b/1.5/debian/docker-entrypoint.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+set -e
+
+# allow the container to be started with `--user`
+if [[ "$*" == node*current/index.js* ]] && [ "$(id -u)" = '0' ]; then
+	chown -R node "$GHOST_CONTENT"
+	exec gosu node "$BASH_SOURCE" "$@"
+fi
+
+if [[ "$*" == node*current/index.js* ]]; then
+	baseDir="$GHOST_INSTALL/content.orig"
+	for src in "$baseDir"/*/ "$baseDir"/themes/*; do
+		src="${src%/}"
+		target="$GHOST_CONTENT/${src#$baseDir/}"
+		mkdir -p "$(dirname "$target")"
+		if [ ! -e "$target" ]; then
+			tar -cC "$(dirname "$src")" "$(basename "$src")" | tar -xC "$(dirname "$target")"
+		fi
+	done
+
+	knex-migrator-migrate --init --mgpath "$GHOST_INSTALL/current"
+fi
+
+exec "$@"

--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -2,7 +2,7 @@
 set -eu
 
 declare -A aliases=(
-	[1.0]='1 latest'
+	[1.3]='1 latest'
 	[0.11]='0'
 )
 defaultVariant='debian'

--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -2,7 +2,7 @@
 set -eu
 
 declare -A aliases=(
-	[1.3]='1 latest'
+	[1.5]='1 latest'
 	[0.11]='0'
 )
 defaultVariant='debian'

--- a/update.sh
+++ b/update.sh
@@ -17,6 +17,15 @@ allVersions="$(
 		| sort -rV
 )"
 
+cliVersion="$(
+	git ls-remote --tags https://github.com/TryGhost/Ghost-CLI.git \
+		| cut -d$'\t' -f2 \
+		| grep -E '^refs/tags/[0-9]+\.[0-9]+' \
+		| cut -d/ -f3 \
+		| sort -rV \
+		| head -n1
+)"
+
 travisEnv=
 for version in "${versions[@]}"; do
 	rcVersion="${version%-rc}"
@@ -41,6 +50,7 @@ for version in "${versions[@]}"; do
 		set -x
 		sed -ri \
 			-e 's/^(ENV GHOST_VERSION) .*/\1 '"$fullVersion"'/' \
+			-e 's/^(ENV GHOST_CLI_VERSION) .*/\1 '"$cliVersion"'/' \
 			"$version"/*/Dockerfile
 	)
 


### PR DESCRIPTION
1.3.0 released 9 hours ago
1.2.0 released 2 days ago
1.1.0 released 4 days ago

We can look to drop some of these (and `0.11`) once they have been pushed to the Docker Hub. Once they are pushed the Docker image will be available regardless of what we continue to update and support.