### PR TITLE
Add ENVIRONMENT GHOST_URL to allow overwrite the default http://local…

### DIFF
--- a/1/alpine/Dockerfile
+++ b/1/alpine/Dockerfile
@@ -13,6 +13,7 @@ ENV NPM_CONFIG_LOGLEVEL warn
 ENV NODE_ENV production
 ENV GHOST_CLI_VERSION 1.0.3
 ENV GHOST_VERSION 1.5.1
+ENV GHOST_URL http://localhost:2368
 
 RUN npm install -g "ghost-cli@$GHOST_CLI_VERSION" knex-migrator@latest
 
@@ -27,7 +28,7 @@ RUN set -ex; \
 	\
 # Tell Ghost to listen on all ips and not prompt for additional configuration
 	cd "$GHOST_INSTALL"; \
-	su-exec node ghost config --ip 0.0.0.0 --port 2368 --no-prompt --db sqlite3 --url http://localhost:2368 --dbpath "$GHOST_CONTENT/data/ghost.db"; \
+	su-exec node ghost config --ip 0.0.0.0 --port 2368 --no-prompt --db sqlite3 --url "$GHOST_URL" --dbpath "$GHOST_CONTENT/data/ghost.db"; \
 	su-exec node ghost config paths.contentPath "$GHOST_CONTENT"; \
 	\
 # need to save initial content for pre-seeding empty volumes

--- a/1/debian/Dockerfile
+++ b/1/debian/Dockerfile
@@ -18,6 +18,7 @@ ENV NPM_CONFIG_LOGLEVEL warn
 ENV NODE_ENV production
 ENV GHOST_CLI_VERSION 1.0.3
 ENV GHOST_VERSION 1.5.1
+ENV GHOST_URL http://localhost:2368
 
 RUN npm install -g "ghost-cli@$GHOST_CLI_VERSION" knex-migrator@latest
 
@@ -32,7 +33,7 @@ RUN set -ex; \
 	\
 # Tell Ghost to listen on all ips and not prompt for additional configuration
 	cd "$GHOST_INSTALL"; \
-	gosu node ghost config --ip 0.0.0.0 --port 2368 --no-prompt --db sqlite3 --url http://localhost:2368 --dbpath "$GHOST_CONTENT/data/ghost.db"; \
+	gosu node ghost config --ip 0.0.0.0 --port 2368 --no-prompt --db sqlite3 --url "$GHOST_URL" --dbpath "$GHOST_CONTENT/data/ghost.db"; \
 	gosu node ghost config paths.contentPath "$GHOST_CONTENT"; \
 	\
 # need to save initial content for pre-seeding empty volumes


### PR DESCRIPTION
…host:2368

The `docker run -e url=http://www.example.com ...` don't work with this image, because of the manual set via `--url` on the config command.