### PR TITLE
Make docker-entrypoint.sh executable

### DIFF
--- a/1/debian/Dockerfile
+++ b/1/debian/Dockerfile
@@ -44,6 +44,7 @@ WORKDIR $GHOST_INSTALL
 VOLUME $GHOST_CONTENT
 
 COPY docker-entrypoint.sh /usr/local/bin
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
 ENTRYPOINT ["docker-entrypoint.sh"]
 
 EXPOSE 2368


### PR DESCRIPTION
When I use this Dockefile, I always get the following error:
```
docker: Error response from daemon: oci runtime error: container_linux.go:247: starting container process caused "exec: \"docker-entrypoint.sh\": executable file not found in $PATH".
```
to which I have solved using this change.