### PR TITLE
Add a config symlink for NODE_ENV=development

### DIFF
--- a/1/alpine/Dockerfile
+++ b/1/alpine/Dockerfile
@@ -30,6 +30,10 @@ RUN set -ex; \
 	su-exec node ghost config --ip 0.0.0.0 --port 2368 --no-prompt --db sqlite3 --url http://localhost:2368 --dbpath "$GHOST_CONTENT/data/ghost.db"; \
 	su-exec node ghost config paths.contentPath "$GHOST_CONTENT"; \
 	\
+# make a config.json symlink for NODE_ENV=development (and sanity check that it's correct)
+	su-exec node ln -s config.production.json "$GHOST_INSTALL/config.development.json"; \
+	readlink -f "$GHOST_INSTALL/config.development.json"; \
+	\
 # need to save initial content for pre-seeding empty volumes
 	mv "$GHOST_CONTENT" "$GHOST_INSTALL/content.orig"; \
 	mkdir -p "$GHOST_CONTENT"; \

--- a/1/debian/Dockerfile
+++ b/1/debian/Dockerfile
@@ -35,6 +35,10 @@ RUN set -ex; \
 	gosu node ghost config --ip 0.0.0.0 --port 2368 --no-prompt --db sqlite3 --url http://localhost:2368 --dbpath "$GHOST_CONTENT/data/ghost.db"; \
 	gosu node ghost config paths.contentPath "$GHOST_CONTENT"; \
 	\
+# make a config.json symlink for NODE_ENV=development (and sanity check that it's correct)
+	gosu node ln -s config.production.json "$GHOST_INSTALL/config.development.json"; \
+	readlink -f "$GHOST_INSTALL/config.development.json"; \
+	\
 # need to save initial content for pre-seeding empty volumes
 	mv "$GHOST_CONTENT" "$GHOST_INSTALL/content.orig"; \
 	mkdir -p "$GHOST_CONTENT"; \


### PR DESCRIPTION
Fixes #99
Refs #97, #91, #88

Filing a concrete PR to give a more direct vessel for discussion/consideration.

I'm not sure why folks feel the need to run with `NODE_ENV=development` (or what it changes), but at least this would ensure it gets the proper config.