### PR TITLE
Fix sqlite3 for non-amd64 arches

### DIFF
--- a/1/alpine/Dockerfile
+++ b/1/alpine/Dockerfile
@@ -9,15 +9,15 @@ RUN apk add --no-cache \
 # add "bash" for "[["
 		bash
 
-ENV NPM_CONFIG_LOGLEVEL warn
 ENV NODE_ENV production
-ENV GHOST_CLI_VERSION 1.2.0
-ENV GHOST_VERSION 1.16.2
 
-RUN npm install -g "ghost-cli@$GHOST_CLI_VERSION" knex-migrator@latest
+ENV GHOST_CLI_VERSION 1.2.0
+RUN npm install -g "ghost-cli@$GHOST_CLI_VERSION"
 
 ENV GHOST_INSTALL /var/lib/ghost
 ENV GHOST_CONTENT /var/lib/ghost/content
+
+ENV GHOST_VERSION 1.16.2
 
 RUN set -ex; \
 	mkdir -p "$GHOST_INSTALL"; \
@@ -37,7 +37,16 @@ RUN set -ex; \
 # need to save initial content for pre-seeding empty volumes
 	mv "$GHOST_CONTENT" "$GHOST_INSTALL/content.orig"; \
 	mkdir -p "$GHOST_CONTENT"; \
-	chown node:node "$GHOST_CONTENT"
+	chown node:node "$GHOST_CONTENT"; \
+	\
+# symlink knex-migrator bins into PATH
+# we want these from the context of Ghost's "node_modules" directory (instead of doing "npm install -g knex-migrator") so they can share the DB driver modules
+	for f in "$GHOST_INSTALL/current/node_modules/.bin/knex-migrator"*; do \
+		[ -x "$f" ]; \
+		ln -svf "$f" /usr/local/bin/; \
+	done
+
+# TODO multiarch sqlite3 (once either "node:6-alpine" has multiarch or we switch to a base that does)
 
 WORKDIR $GHOST_INSTALL
 VOLUME $GHOST_CONTENT

--- a/1/debian/Dockerfile
+++ b/1/debian/Dockerfile
@@ -14,15 +14,15 @@ RUN set -x \
 	&& chmod +x /usr/local/bin/gosu \
 	&& gosu nobody true
 
-ENV NPM_CONFIG_LOGLEVEL warn
 ENV NODE_ENV production
-ENV GHOST_CLI_VERSION 1.2.0
-ENV GHOST_VERSION 1.16.2
 
-RUN npm install -g "ghost-cli@$GHOST_CLI_VERSION" knex-migrator@latest
+ENV GHOST_CLI_VERSION 1.2.0
+RUN npm install -g "ghost-cli@$GHOST_CLI_VERSION"
 
 ENV GHOST_INSTALL /var/lib/ghost
 ENV GHOST_CONTENT /var/lib/ghost/content
+
+ENV GHOST_VERSION 1.16.2
 
 RUN set -ex; \
 	mkdir -p "$GHOST_INSTALL"; \
@@ -42,7 +42,35 @@ RUN set -ex; \
 # need to save initial content for pre-seeding empty volumes
 	mv "$GHOST_CONTENT" "$GHOST_INSTALL/content.orig"; \
 	mkdir -p "$GHOST_CONTENT"; \
-	chown node:node "$GHOST_CONTENT"
+	chown node:node "$GHOST_CONTENT"; \
+	\
+# symlink knex-migrator bins into PATH
+# we want these from the context of Ghost's "node_modules" directory (instead of doing "npm install -g knex-migrator") so they can share the DB driver modules
+	for f in "$GHOST_INSTALL/current/node_modules/.bin/knex-migrator"*; do \
+		[ -x "$f" ]; \
+		ln -svf "$f" /usr/local/bin/; \
+	done
+
+RUN set -eux; \
+# force install "sqlite3" manually since it's an optional dependency of "ghost"
+# (which means that if it fails to install, like on ARM/ppc64le/s390x, the failure will be silently ignored and thus turn into a runtime error instead)
+# see https://github.com/TryGhost/Ghost/pull/7677 for more details
+	cd "$GHOST_INSTALL/current"; \
+# scrape the expected version of sqlite3 directly from Ghost itself
+	sqlite3Version="$(npm view . optionalDependencies.sqlite3)"; \
+	if ! gosu node npm install "sqlite3@$sqlite3Version"; then \
+# must be some non-amd64 architecture pre-built binaries aren't published for, so let's install some build deps and do-it-all-over-again
+		savedAptMark="$(apt-mark showmanual)"; \
+		apt-get update; \
+		apt-get install -y --no-install-recommends python make gcc g++ libc-dev; \
+		rm -rf /var/lib/apt/lists/*; \
+		\
+		gosu node npm install "sqlite3@$sqlite3Version" --build-from-source; \
+		\
+		apt-mark showmanual | xargs apt-mark auto > /dev/null; \
+		[ -z "$savedAptMark" ] || apt-mark manual $savedAptMark; \
+		apt-get purge -y --auto-remove; \
+	fi
 
 WORKDIR $GHOST_INSTALL
 VOLUME $GHOST_CONTENT


### PR DESCRIPTION
Closes #98

See also https://github.com/TryGhost/Ghost/pull/7677 for more details (which is the PR which moved `sqlite3` into optional dependencies upstream, and has some good discussion around that move).

Basically, the complexity of this PR is exactly why they made this dependency optional in the first place, but given that we use it as our default driver, we kind of need to have the default image run as-is on all platforms we support. :smile: