### PR TITLE
FEAT: Added a stronger test into the travis build script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,18 @@ before_script:
 script:
   - travis_retry docker build -t "$image" "$VARIANT"
   - ~/official-images/test/run.sh "$image"
+  - docker run -d --name blogtest -p 2368:2368 -e NODE_ENV=production "$image"
+  - until nc -z $(docker inspect --format='{{.NetworkSettings.IPAddress}}' blogtest) 2368; do
+      echo "waiting for ghostblog container...";
+      sleep 2;
+    done
+  - echo "GhostTest available..."
+  - curl http://localhost:2368 | grep "The professional publishing platform"
 
 after_script:
   - docker images
+  - docker logs blogtest
+  - docker stop blogtest
+  - docker rm blogtest
 
 # vim:set et ts=2 sw=2:


### PR DESCRIPTION
To be sure the Docker image is correctly working, I added a test into the travis file. What it will do is:

- Start a test Ghost with the generated image
- Wait until the image is started up (and database created)
- Get the homepage of the Ghostblog
- Check if the response page contains what is excepted

I'm using it on this build and already helped me to push unstable images (which are pushed automatically by travis)
