### PR TITLE
add alpine image for ghost2

### DIFF
--- a/2/alpine/Dockerfile
+++ b/2/alpine/Dockerfile
@@ -1,0 +1,60 @@
+
+# https://docs.ghost.org/supported-node-versions/
+# https://github.com/nodejs/LTS
+FROM node:8-alpine
+
+# grab su-exec for easy step-down from root
+RUN apk add --no-cache 'su-exec>=0.2'
+
+RUN apk add --no-cache \
+# add "bash" for "[["
+		bash
+
+ENV NODE_ENV production
+
+ENV GHOST_CLI_VERSION 1.9.1
+RUN npm install -g "ghost-cli@$GHOST_CLI_VERSION"
+
+ENV GHOST_INSTALL /var/lib/ghost
+ENV GHOST_CONTENT /var/lib/ghost/content
+
+ENV GHOST_VERSION 2.0.2
+
+RUN set -ex; \
+	mkdir -p "$GHOST_INSTALL"; \
+	chown node:node "$GHOST_INSTALL"; \
+	\
+	su-exec node ghost install "$GHOST_VERSION" --db sqlite3 --no-prompt --no-stack --no-setup --dir "$GHOST_INSTALL"; \
+	\
+# Tell Ghost to listen on all ips and not prompt for additional configuration
+	cd "$GHOST_INSTALL"; \
+	su-exec node ghost config --ip 0.0.0.0 --port 2368 --no-prompt --db sqlite3 --url http://localhost:2368 --dbpath "$GHOST_CONTENT/data/ghost.db"; \
+	su-exec node ghost config paths.contentPath "$GHOST_CONTENT"; \
+	\
+# make a config.json symlink for NODE_ENV=development (and sanity check that it's correct)
+	su-exec node ln -s config.production.json "$GHOST_INSTALL/config.development.json"; \
+	readlink -f "$GHOST_INSTALL/config.development.json"; \
+	\
+# need to save initial content for pre-seeding empty volumes
+	mv "$GHOST_CONTENT" "$GHOST_INSTALL/content.orig"; \
+	mkdir -p "$GHOST_CONTENT"; \
+	chown node:node "$GHOST_CONTENT"; \
+	\
+# sanity check to ensure knex-migrator was installed
+	"$GHOST_INSTALL/current/node_modules/knex-migrator/bin/knex-migrator" --version
+
+# add knex-migrator bins into PATH
+# we want these from the context of Ghost's "node_modules" directory (instead of doing "npm install -g knex-migrator") so they can share the DB driver modules
+ENV PATH $PATH:$GHOST_INSTALL/current/node_modules/knex-migrator/bin
+
+# TODO multiarch sqlite3 (once either "node:6-alpine" has multiarch or we switch to a base that does)
+
+WORKDIR $GHOST_INSTALL
+VOLUME $GHOST_CONTENT
+
+COPY docker-entrypoint.sh /usr/local/bin
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
+
+EXPOSE 2368
+CMD ["node", "current/index.js"]

--- a/2/alpine/docker-entrypoint.sh
+++ b/2/alpine/docker-entrypoint.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+set -e
+
+# allow the container to be started with `--user`
+if [[ "$*" == node*current/index.js* ]] && [ "$(id -u)" = '0' ]; then
+	chown -R node "$GHOST_CONTENT"
+	exec su-exec node "$BASH_SOURCE" "$@"
+fi
+
+if [[ "$*" == node*current/index.js* ]]; then
+	baseDir="$GHOST_INSTALL/content.orig"
+	for src in "$baseDir"/*/ "$baseDir"/themes/*; do
+		src="${src%/}"
+		target="$GHOST_CONTENT/${src#$baseDir/}"
+		mkdir -p "$(dirname "$target")"
+		if [ ! -e "$target" ]; then
+			tar -cC "$(dirname "$src")" "$(basename "$src")" | tar -xC "$(dirname "$target")"
+		fi
+	done
+
+	knex-migrator-migrate --init --mgpath "$GHOST_INSTALL/current"
+fi
+
+exec "$@"


### PR DESCRIPTION
This is based on the ghost-1.0 alpine image.
I had to add line `RUN chmod +x /usr/local/bin/docker-entrypoint.sh` to make it work - not a docker expert.

Maybe this helps someone to try 2.0 asap (#142 ) :)

Build with
`docker build --no-cache -t ghost/ghost:2 .`

Run with
`docker run -d --name <ender-name> -p 3001:2368 ghost/ghost:2`