### PR TITLE
add ghost v2 docker images

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: bash
 services: docker
 
 env:
+  - VERSION=2 VARIANT=debian
+  - VERSION=2 VARIANT=alpine
   - VERSION=1 VARIANT=debian
   - VERSION=1 VARIANT=alpine
   - VERSION=0 VARIANT=debian

--- a/2/alpine/Dockerfile
+++ b/2/alpine/Dockerfile
@@ -1,0 +1,51 @@
+# https://docs.ghost.org/supported-node-versions/
+# https://github.com/nodejs/LTS
+FROM node:8-alpine
+
+# grab su-exec for easy step-down from root
+RUN apk add --no-cache 'su-exec>=0.2'
+
+RUN apk add --no-cache \
+# add "bash" for "[["
+		bash
+
+ENV NODE_ENV production
+
+ENV GHOST_CLI_VERSION 1.9.1
+RUN npm install -g "ghost-cli@$GHOST_CLI_VERSION"
+
+ENV GHOST_INSTALL /var/lib/ghost
+ENV GHOST_CONTENT /var/lib/ghost/content
+
+ENV GHOST_VERSION 2.0.3
+
+RUN set -ex; \
+	mkdir -p "$GHOST_INSTALL"; \
+	chown node:node "$GHOST_INSTALL"; \
+	\
+	su-exec node ghost install "$GHOST_VERSION" --db sqlite3 --no-prompt --no-stack --no-setup --dir "$GHOST_INSTALL"; \
+	\
+# Tell Ghost to listen on all ips and not prompt for additional configuration
+	cd "$GHOST_INSTALL"; \
+	su-exec node ghost config --ip 0.0.0.0 --port 2368 --no-prompt --db sqlite3 --url http://localhost:2368 --dbpath "$GHOST_CONTENT/data/ghost.db"; \
+	su-exec node ghost config paths.contentPath "$GHOST_CONTENT"; \
+	\
+# make a config.json symlink for NODE_ENV=development (and sanity check that it's correct)
+	su-exec node ln -s config.production.json "$GHOST_INSTALL/config.development.json"; \
+	readlink -f "$GHOST_INSTALL/config.development.json"; \
+	\
+# need to save initial content for pre-seeding empty volumes
+	mv "$GHOST_CONTENT" "$GHOST_INSTALL/content.orig"; \
+	mkdir -p "$GHOST_CONTENT"; \
+	chown node:node "$GHOST_CONTENT"
+
+# TODO multiarch sqlite3 (once either "node:6-alpine" has multiarch or we switch to a base that does)
+
+WORKDIR $GHOST_INSTALL
+VOLUME $GHOST_CONTENT
+
+COPY docker-entrypoint.sh /usr/local/bin
+ENTRYPOINT ["docker-entrypoint.sh"]
+
+EXPOSE 2368
+CMD ["node", "current/index.js"]

--- a/2/alpine/docker-entrypoint.sh
+++ b/2/alpine/docker-entrypoint.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+set -e
+
+# allow the container to be started with `--user`
+if [[ "$*" == node*current/index.js* ]] && [ "$(id -u)" = '0' ]; then
+	chown -R node "$GHOST_CONTENT"
+	exec su-exec node "$BASH_SOURCE" "$@"
+fi
+
+if [[ "$*" == node*current/index.js* ]]; then
+	baseDir="$GHOST_INSTALL/content.orig"
+	for src in "$baseDir"/*/ "$baseDir"/themes/*; do
+		src="${src%/}"
+		target="$GHOST_CONTENT/${src#$baseDir/}"
+		mkdir -p "$(dirname "$target")"
+		if [ ! -e "$target" ]; then
+			tar -cC "$(dirname "$src")" "$(basename "$src")" | tar -xC "$(dirname "$target")"
+		fi
+	done
+fi
+
+exec "$@"

--- a/2/debian/Dockerfile
+++ b/2/debian/Dockerfile
@@ -1,0 +1,76 @@
+# https://docs.ghost.org/supported-node-versions/
+# https://github.com/nodejs/LTS
+FROM node:8-slim
+
+# grab gosu for easy step-down from root
+ENV GOSU_VERSION 1.10
+RUN set -x \
+	&& wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$(dpkg --print-architecture)" \
+	&& wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$(dpkg --print-architecture).asc" \
+	&& export GNUPGHOME="$(mktemp -d)" \
+	&& gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
+	&& gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu \
+	&& { command -v gpgconf && gpgconf --kill all || :; } \
+	&& rm -r "$GNUPGHOME" /usr/local/bin/gosu.asc \
+	&& chmod +x /usr/local/bin/gosu \
+	&& gosu nobody true
+
+ENV NODE_ENV production
+
+ENV GHOST_CLI_VERSION 1.9.1
+RUN npm install -g "ghost-cli@$GHOST_CLI_VERSION"
+
+ENV GHOST_INSTALL /var/lib/ghost
+ENV GHOST_CONTENT /var/lib/ghost/content
+
+ENV GHOST_VERSION 2.0.3
+
+RUN set -ex; \
+	mkdir -p "$GHOST_INSTALL"; \
+	chown node:node "$GHOST_INSTALL"; \
+	\
+	gosu node ghost install "$GHOST_VERSION" --db sqlite3 --no-prompt --no-stack --no-setup --dir "$GHOST_INSTALL"; \
+	\
+# Tell Ghost to listen on all ips and not prompt for additional configuration
+	cd "$GHOST_INSTALL"; \
+	gosu node ghost config --ip 0.0.0.0 --port 2368 --no-prompt --db sqlite3 --url http://localhost:2368 --dbpath "$GHOST_CONTENT/data/ghost.db"; \
+	gosu node ghost config paths.contentPath "$GHOST_CONTENT"; \
+	\
+# make a config.json symlink for NODE_ENV=development (and sanity check that it's correct)
+	gosu node ln -s config.production.json "$GHOST_INSTALL/config.development.json"; \
+	readlink -f "$GHOST_INSTALL/config.development.json"; \
+	\
+# need to save initial content for pre-seeding empty volumes
+	mv "$GHOST_CONTENT" "$GHOST_INSTALL/content.orig"; \
+	mkdir -p "$GHOST_CONTENT"; \
+	chown node:node "$GHOST_CONTENT"
+
+RUN set -eux; \
+# force install "sqlite3" manually since it's an optional dependency of "ghost"
+# (which means that if it fails to install, like on ARM/ppc64le/s390x, the failure will be silently ignored and thus turn into a runtime error instead)
+# see https://github.com/TryGhost/Ghost/pull/7677 for more details
+	cd "$GHOST_INSTALL/current"; \
+# scrape the expected version of sqlite3 directly from Ghost itself
+	sqlite3Version="$(npm view . optionalDependencies.sqlite3)"; \
+	if ! gosu node yarn add "sqlite3@$sqlite3Version" --force; then \
+# must be some non-amd64 architecture pre-built binaries aren't published for, so let's install some build deps and do-it-all-over-again
+		savedAptMark="$(apt-mark showmanual)"; \
+		apt-get update; \
+		apt-get install -y --no-install-recommends python make gcc g++ libc-dev; \
+		rm -rf /var/lib/apt/lists/*; \
+		\
+		gosu node yarn add "sqlite3@$sqlite3Version" --force --build-from-source; \
+		\
+		apt-mark showmanual | xargs apt-mark auto > /dev/null; \
+		[ -z "$savedAptMark" ] || apt-mark manual $savedAptMark; \
+		apt-get purge -y --auto-remove; \
+	fi
+
+WORKDIR $GHOST_INSTALL
+VOLUME $GHOST_CONTENT
+
+COPY docker-entrypoint.sh /usr/local/bin
+ENTRYPOINT ["docker-entrypoint.sh"]
+
+EXPOSE 2368
+CMD ["node", "current/index.js"]

--- a/2/debian/docker-entrypoint.sh
+++ b/2/debian/docker-entrypoint.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+set -e
+
+# allow the container to be started with `--user`
+if [[ "$*" == node*current/index.js* ]] && [ "$(id -u)" = '0' ]; then
+	chown -R node "$GHOST_CONTENT"
+	exec gosu node "$BASH_SOURCE" "$@"
+fi
+
+if [[ "$*" == node*current/index.js* ]]; then
+	baseDir="$GHOST_INSTALL/content.orig"
+	for src in "$baseDir"/*/ "$baseDir"/themes/*; do
+		src="${src%/}"
+		target="$GHOST_CONTENT/${src#$baseDir/}"
+		mkdir -p "$(dirname "$target")"
+		if [ ! -e "$target" ]; then
+			tar -cC "$(dirname "$src")" "$(basename "$src")" | tar -xC "$(dirname "$target")"
+		fi
+	done
+fi
+
+exec "$@"


### PR DESCRIPTION
closes #142 

Main difference from ghost v1 is that knex-migrator is no longer needed outside of Ghost - Ghost itself will run it on boot.