### PR TITLE
Only chown things in the entrypoint that are not already owned by node

### DIFF
--- a/0/alpine/docker-entrypoint.sh
+++ b/0/alpine/docker-entrypoint.sh
@@ -3,7 +3,7 @@ set -e
 
 # allow the container to be started with `--user`
 if [[ "$*" == npm*start* ]] && [ "$(id -u)" = '0' ]; then
-	chown -R node "$GHOST_CONTENT"
+	find "$GHOST_CONTENT" \! -user node -exec chown node '{}' +
 	exec su-exec node "$BASH_SOURCE" "$@"
 fi
 

--- a/0/debian/docker-entrypoint.sh
+++ b/0/debian/docker-entrypoint.sh
@@ -3,7 +3,7 @@ set -e
 
 # allow the container to be started with `--user`
 if [[ "$*" == npm*start* ]] && [ "$(id -u)" = '0' ]; then
-	chown -R user "$GHOST_CONTENT"
+	find "$GHOST_CONTENT" \! -user node -exec chown node '{}' +
 	exec gosu user "$BASH_SOURCE" "$@"
 fi
 

--- a/0/debian/docker-entrypoint.sh
+++ b/0/debian/docker-entrypoint.sh
@@ -3,7 +3,7 @@ set -e
 
 # allow the container to be started with `--user`
 if [[ "$*" == npm*start* ]] && [ "$(id -u)" = '0' ]; then
-	find "$GHOST_CONTENT" \! -user node -exec chown node '{}' +
+	find "$GHOST_CONTENT" \! -user user -exec chown user '{}' +
 	exec gosu user "$BASH_SOURCE" "$@"
 fi
 

--- a/1/alpine/docker-entrypoint.sh
+++ b/1/alpine/docker-entrypoint.sh
@@ -3,7 +3,7 @@ set -e
 
 # allow the container to be started with `--user`
 if [[ "$*" == node*current/index.js* ]] && [ "$(id -u)" = '0' ]; then
-	chown -R node "$GHOST_CONTENT"
+	find "$GHOST_CONTENT" \! -user node -exec chown node '{}' +
 	exec su-exec node "$BASH_SOURCE" "$@"
 fi
 

--- a/1/debian/docker-entrypoint.sh
+++ b/1/debian/docker-entrypoint.sh
@@ -3,7 +3,7 @@ set -e
 
 # allow the container to be started with `--user`
 if [[ "$*" == node*current/index.js* ]] && [ "$(id -u)" = '0' ]; then
-	chown -R node "$GHOST_CONTENT"
+	find "$GHOST_CONTENT" \! -user node -exec chown node '{}' +
 	exec gosu node "$BASH_SOURCE" "$@"
 fi
 

--- a/2/alpine/docker-entrypoint.sh
+++ b/2/alpine/docker-entrypoint.sh
@@ -3,7 +3,7 @@ set -e
 
 # allow the container to be started with `--user`
 if [[ "$*" == node*current/index.js* ]] && [ "$(id -u)" = '0' ]; then
-	chown -R node "$GHOST_CONTENT"
+	find "$GHOST_CONTENT" \! -user node -exec chown node '{}' +
 	exec su-exec node "$BASH_SOURCE" "$@"
 fi
 

--- a/2/debian/docker-entrypoint.sh
+++ b/2/debian/docker-entrypoint.sh
@@ -3,7 +3,7 @@ set -e
 
 # allow the container to be started with `--user`
 if [[ "$*" == node*current/index.js* ]] && [ "$(id -u)" = '0' ]; then
-	chown -R node "$GHOST_CONTENT"
+	find "$GHOST_CONTENT" \! -user node -exec chown node '{}' +
 	exec gosu node "$BASH_SOURCE" "$@"
 fi
 


### PR DESCRIPTION
Same as https://github.com/docker-library/rabbitmq/pull/281, https://github.com/docker-library/mariadb/pull/203, https://github.com/docker-library/percona/pull/69, https://github.com/docker-library/redmine/pull/128, https://github.com/docker-library/mongo/pull/305, https://github.com/docker-library/cassandra/pull/158, https://github.com/docker-library/redis/pull/166, https://github.com/docker-library/owncloud/pull/105