### PR TITLE
Move Ghost 2 over to Node.js 10

### DIFF
--- a/2/alpine/Dockerfile
+++ b/2/alpine/Dockerfile
@@ -1,6 +1,6 @@
-# https://docs.ghost.org/supported-node-versions/
+# https://docs.ghost.org/faq/node-versions/
 # https://github.com/nodejs/LTS
-FROM node:8-alpine
+FROM node:10-alpine
 
 # grab su-exec for easy step-down from root
 RUN apk add --no-cache 'su-exec>=0.2'

--- a/2/debian/Dockerfile
+++ b/2/debian/Dockerfile
@@ -1,6 +1,6 @@
-# https://docs.ghost.org/supported-node-versions/
+# https://docs.ghost.org/faq/node-versions/
 # https://github.com/nodejs/LTS
-FROM node:8-slim
+FROM node:10-slim
 
 # grab gosu for easy step-down from root
 ENV GOSU_VERSION 1.10


### PR DESCRIPTION
Closes #178

I don't think Ghost 1 supports/recommends Node.js 10 (yet?) -- I was kind of wondering if Ghost 1 is still actively supported upstream?  (last release appears to be 1.25.7 on Feb 7, which _is_ still plausible for being actively supported)