### PR TITLE
Reduce 2-alpine image size

### DIFF
--- a/1/alpine/Dockerfile
+++ b/1/alpine/Dockerfile
@@ -12,14 +12,16 @@ RUN apk add --no-cache \
 ENV NODE_ENV production
 
 ENV GHOST_CLI_VERSION 1.11.0
-RUN npm install -g "ghost-cli@$GHOST_CLI_VERSION"
+RUN set -eux; \
+	npm install -g "ghost-cli@$GHOST_CLI_VERSION"; \
+	npm cache clean --force
 
 ENV GHOST_INSTALL /var/lib/ghost
 ENV GHOST_CONTENT /var/lib/ghost/content
 
 ENV GHOST_VERSION 1.25.8
 
-RUN set -ex; \
+RUN set -eux; \
 	mkdir -p "$GHOST_INSTALL"; \
 	chown node:node "$GHOST_INSTALL"; \
 	\
@@ -40,13 +42,8 @@ RUN set -ex; \
 	chown node:node "$GHOST_CONTENT"; \
 	\
 # sanity check to ensure knex-migrator was installed
-	"$GHOST_INSTALL/current/node_modules/knex-migrator/bin/knex-migrator" --version
-
-# add knex-migrator bins into PATH
-# we want these from the context of Ghost's "node_modules" directory (instead of doing "npm install -g knex-migrator") so they can share the DB driver modules
-ENV PATH $PATH:$GHOST_INSTALL/current/node_modules/knex-migrator/bin
-
-RUN set -eux; \
+	"$GHOST_INSTALL/current/node_modules/knex-migrator/bin/knex-migrator" --version; \
+	\
 # force install "sqlite3" manually since it's an optional dependency of "ghost"
 # (which means that if it fails to install, like on ARM/ppc64le/s390x, the failure will be silently ignored and thus turn into a runtime error instead)
 # see https://github.com/TryGhost/Ghost/pull/7677 for more details
@@ -60,7 +57,16 @@ RUN set -eux; \
 		su-exec node yarn add "sqlite3@$sqlite3Version" --force --build-from-source; \
 		\
 		apk del --no-network .build-deps; \
-	fi
+	fi; \
+	\
+	su-exec node yarn cache clean; \
+	su-exec node npm cache clean --force; \
+	npm cache clean --force; \
+	rm -r /tmp/*
+
+# add knex-migrator bins into PATH
+# we want these from the context of Ghost's "node_modules" directory (instead of doing "npm install -g knex-migrator") so they can share the DB driver modules
+ENV PATH $PATH:$GHOST_INSTALL/current/node_modules/knex-migrator/bin
 
 WORKDIR $GHOST_INSTALL
 VOLUME $GHOST_CONTENT

--- a/1/alpine/Dockerfile
+++ b/1/alpine/Dockerfile
@@ -62,7 +62,7 @@ RUN set -eux; \
 	su-exec node yarn cache clean; \
 	su-exec node npm cache clean --force; \
 	npm cache clean --force; \
-	rm -r /tmp/*
+	rm -rv /tmp/yarn* /tmp/v8*
 
 # add knex-migrator bins into PATH
 # we want these from the context of Ghost's "node_modules" directory (instead of doing "npm install -g knex-migrator") so they can share the DB driver modules

--- a/1/debian/Dockerfile
+++ b/1/debian/Dockerfile
@@ -18,14 +18,16 @@ RUN set -x \
 ENV NODE_ENV production
 
 ENV GHOST_CLI_VERSION 1.11.0
-RUN npm install -g "ghost-cli@$GHOST_CLI_VERSION"
+RUN set -eux; \
+	npm install -g "ghost-cli@$GHOST_CLI_VERSION"; \
+	npm cache clean --force
 
 ENV GHOST_INSTALL /var/lib/ghost
 ENV GHOST_CONTENT /var/lib/ghost/content
 
 ENV GHOST_VERSION 1.25.8
 
-RUN set -ex; \
+RUN set -eux; \
 	mkdir -p "$GHOST_INSTALL"; \
 	chown node:node "$GHOST_INSTALL"; \
 	\
@@ -46,13 +48,8 @@ RUN set -ex; \
 	chown node:node "$GHOST_CONTENT"; \
 	\
 # sanity check to ensure knex-migrator was installed
-	"$GHOST_INSTALL/current/node_modules/knex-migrator/bin/knex-migrator" --version
-
-# add knex-migrator bins into PATH
-# we want these from the context of Ghost's "node_modules" directory (instead of doing "npm install -g knex-migrator") so they can share the DB driver modules
-ENV PATH $PATH:$GHOST_INSTALL/current/node_modules/knex-migrator/bin
-
-RUN set -eux; \
+	"$GHOST_INSTALL/current/node_modules/knex-migrator/bin/knex-migrator" --version; \
+	\
 # force install "sqlite3" manually since it's an optional dependency of "ghost"
 # (which means that if it fails to install, like on ARM/ppc64le/s390x, the failure will be silently ignored and thus turn into a runtime error instead)
 # see https://github.com/TryGhost/Ghost/pull/7677 for more details
@@ -71,7 +68,16 @@ RUN set -eux; \
 		apt-mark showmanual | xargs apt-mark auto > /dev/null; \
 		[ -z "$savedAptMark" ] || apt-mark manual $savedAptMark; \
 		apt-get purge -y --auto-remove; \
-	fi
+	fi; \
+	\
+	gosu node yarn cache clean; \
+	gosu node npm cache clean --force; \
+	npm cache clean --force; \
+	rm -r /tmp/*
+
+# add knex-migrator bins into PATH
+# we want these from the context of Ghost's "node_modules" directory (instead of doing "npm install -g knex-migrator") so they can share the DB driver modules
+ENV PATH $PATH:$GHOST_INSTALL/current/node_modules/knex-migrator/bin
 
 WORKDIR $GHOST_INSTALL
 VOLUME $GHOST_CONTENT

--- a/1/debian/Dockerfile
+++ b/1/debian/Dockerfile
@@ -73,7 +73,7 @@ RUN set -eux; \
 	gosu node yarn cache clean; \
 	gosu node npm cache clean --force; \
 	npm cache clean --force; \
-	rm -r /tmp/*
+	rm -rv /tmp/yarn* /tmp/v8*
 
 # add knex-migrator bins into PATH
 # we want these from the context of Ghost's "node_modules" directory (instead of doing "npm install -g knex-migrator") so they can share the DB driver modules

--- a/2/alpine/Dockerfile
+++ b/2/alpine/Dockerfile
@@ -37,9 +37,9 @@ RUN set -ex; \
 # need to save initial content for pre-seeding empty volumes
 	mv "$GHOST_CONTENT" "$GHOST_INSTALL/content.orig"; \
 	mkdir -p "$GHOST_CONTENT"; \
-	chown node:node "$GHOST_CONTENT"
-
-RUN set -eux; \
+	chown node:node "$GHOST_CONTENT"; \
+    \
+    set -eux; \
 # force install "sqlite3" manually since it's an optional dependency of "ghost"
 # (which means that if it fails to install, like on ARM/ppc64le/s390x, the failure will be silently ignored and thus turn into a runtime error instead)
 # see https://github.com/TryGhost/Ghost/pull/7677 for more details
@@ -53,7 +53,12 @@ RUN set -eux; \
 		su-exec node yarn add "sqlite3@$sqlite3Version" --force --build-from-source; \
 		\
 		apk del --no-network .build-deps; \
-	fi
+	fi; \
+	\
+	su-exec node yarn cache clean; \
+    su-exec node npm cache clean --force; \
+	npm cache clean --force; \
+	rm -r /tmp/*
 
 WORKDIR $GHOST_INSTALL
 VOLUME $GHOST_CONTENT

--- a/2/alpine/Dockerfile
+++ b/2/alpine/Dockerfile
@@ -59,7 +59,7 @@ RUN set -eux; \
 	su-exec node yarn cache clean; \
 	su-exec node npm cache clean --force; \
 	npm cache clean --force; \
-	rm -r /tmp/*
+	rm -rv /tmp/yarn* /tmp/v8*
 
 WORKDIR $GHOST_INSTALL
 VOLUME $GHOST_CONTENT

--- a/2/alpine/Dockerfile
+++ b/2/alpine/Dockerfile
@@ -56,7 +56,7 @@ RUN set -ex; \
 	fi; \
 	\
 	su-exec node yarn cache clean; \
-    su-exec node npm cache clean --force; \
+	su-exec node npm cache clean --force; \
 	npm cache clean --force; \
 	rm -r /tmp/*
 

--- a/2/alpine/Dockerfile
+++ b/2/alpine/Dockerfile
@@ -12,14 +12,16 @@ RUN apk add --no-cache \
 ENV NODE_ENV production
 
 ENV GHOST_CLI_VERSION 1.11.0
-RUN npm install -g "ghost-cli@$GHOST_CLI_VERSION"
+RUN set -eux; \
+	npm install -g "ghost-cli@$GHOST_CLI_VERSION"; \
+	npm cache clean --force
 
 ENV GHOST_INSTALL /var/lib/ghost
 ENV GHOST_CONTENT /var/lib/ghost/content
 
 ENV GHOST_VERSION 2.23.3
 
-RUN set -ex; \
+RUN set -eux; \
 	mkdir -p "$GHOST_INSTALL"; \
 	chown node:node "$GHOST_INSTALL"; \
 	\
@@ -38,8 +40,7 @@ RUN set -ex; \
 	mv "$GHOST_CONTENT" "$GHOST_INSTALL/content.orig"; \
 	mkdir -p "$GHOST_CONTENT"; \
 	chown node:node "$GHOST_CONTENT"; \
-    \
-    set -eux; \
+	\
 # force install "sqlite3" manually since it's an optional dependency of "ghost"
 # (which means that if it fails to install, like on ARM/ppc64le/s390x, the failure will be silently ignored and thus turn into a runtime error instead)
 # see https://github.com/TryGhost/Ghost/pull/7677 for more details

--- a/2/debian/Dockerfile
+++ b/2/debian/Dockerfile
@@ -18,14 +18,16 @@ RUN set -x \
 ENV NODE_ENV production
 
 ENV GHOST_CLI_VERSION 1.11.0
-RUN npm install -g "ghost-cli@$GHOST_CLI_VERSION"
+RUN set -eux; \
+	npm install -g "ghost-cli@$GHOST_CLI_VERSION"; \
+	npm cache clean --force
 
 ENV GHOST_INSTALL /var/lib/ghost
 ENV GHOST_CONTENT /var/lib/ghost/content
 
 ENV GHOST_VERSION 2.23.3
 
-RUN set -ex; \
+RUN set -eux; \
 	mkdir -p "$GHOST_INSTALL"; \
 	chown node:node "$GHOST_INSTALL"; \
 	\
@@ -43,9 +45,8 @@ RUN set -ex; \
 # need to save initial content for pre-seeding empty volumes
 	mv "$GHOST_CONTENT" "$GHOST_INSTALL/content.orig"; \
 	mkdir -p "$GHOST_CONTENT"; \
-	chown node:node "$GHOST_CONTENT"
-
-RUN set -eux; \
+	chown node:node "$GHOST_CONTENT"; \
+	\
 # force install "sqlite3" manually since it's an optional dependency of "ghost"
 # (which means that if it fails to install, like on ARM/ppc64le/s390x, the failure will be silently ignored and thus turn into a runtime error instead)
 # see https://github.com/TryGhost/Ghost/pull/7677 for more details
@@ -64,7 +65,12 @@ RUN set -eux; \
 		apt-mark showmanual | xargs apt-mark auto > /dev/null; \
 		[ -z "$savedAptMark" ] || apt-mark manual $savedAptMark; \
 		apt-get purge -y --auto-remove; \
-	fi
+	fi; \
+	\
+	gosu node yarn cache clean; \
+	gosu node npm cache clean --force; \
+	npm cache clean --force; \
+	rm -r /tmp/*
 
 WORKDIR $GHOST_INSTALL
 VOLUME $GHOST_CONTENT

--- a/2/debian/Dockerfile
+++ b/2/debian/Dockerfile
@@ -70,7 +70,7 @@ RUN set -eux; \
 	gosu node yarn cache clean; \
 	gosu node npm cache clean --force; \
 	npm cache clean --force; \
-	rm -r /tmp/*
+	rm -rv /tmp/yarn* /tmp/v8*
 
 WORKDIR $GHOST_INSTALL
 VOLUME $GHOST_CONTENT


### PR DESCRIPTION
- Clean up the cached files at the end of image creation
- Flatten the two layers created by the two RUN blocks into one
  - Putting them together into one RUN block means files written and subsequently deleted at the end aren't preserved in the intermediate layer.

These changes reduce the image size by approximately 300 MB. Containers based off this image that install npm packages should simply re-download the files rather than use the cached version - there should be no actual impact to the operation of the image.