### PR TITLE
change build dep since "python" doesn't exist in Alpine anymore (or Debian bullseye)

### DIFF
--- a/2/alpine/Dockerfile
+++ b/2/alpine/Dockerfile
@@ -51,9 +51,9 @@ RUN set -eux; \
 	sqlite3Version="$(node -p 'require("./package.json").optionalDependencies.sqlite3')"; \
 	if ! su-exec node yarn add "sqlite3@$sqlite3Version" --force; then \
 # must be some non-amd64 architecture pre-built binaries aren't published for, so let's install some build deps and do-it-all-over-again
-		apk add --no-cache --virtual .build-deps python3 make gcc g++ libc-dev; \
+		apk add --no-cache --virtual .build-deps g++ gcc libc-dev make python3 vips-dev; \
 		\
-		su-exec node yarn add "sqlite3@$sqlite3Version" --force --build-from-source; \
+		npm_config_python='python3' su-exec node yarn add "sqlite3@$sqlite3Version" --force --build-from-source; \
 		\
 		apk del --no-network .build-deps; \
 	fi; \

--- a/2/alpine/Dockerfile
+++ b/2/alpine/Dockerfile
@@ -51,7 +51,7 @@ RUN set -eux; \
 	sqlite3Version="$(node -p 'require("./package.json").optionalDependencies.sqlite3')"; \
 	if ! su-exec node yarn add "sqlite3@$sqlite3Version" --force; then \
 # must be some non-amd64 architecture pre-built binaries aren't published for, so let's install some build deps and do-it-all-over-again
-		apk add --no-cache --virtual .build-deps python make gcc g++ libc-dev; \
+		apk add --no-cache --virtual .build-deps python3 make gcc g++ libc-dev; \
 		\
 		su-exec node yarn add "sqlite3@$sqlite3Version" --force --build-from-source; \
 		\

--- a/2/debian/Dockerfile
+++ b/2/debian/Dockerfile
@@ -77,10 +77,10 @@ RUN set -eux; \
 # must be some non-amd64 architecture pre-built binaries aren't published for, so let's install some build deps and do-it-all-over-again
 		savedAptMark="$(apt-mark showmanual)"; \
 		apt-get update; \
-		apt-get install -y --no-install-recommends python3 make gcc g++ libc-dev; \
+		apt-get install -y --no-install-recommends g++ gcc libc-dev make python3; \
 		rm -rf /var/lib/apt/lists/*; \
 		\
-		gosu node yarn add "sqlite3@$sqlite3Version" --force --build-from-source; \
+		npm_config_python='python3' gosu node yarn add "sqlite3@$sqlite3Version" --force --build-from-source; \
 		\
 		apt-mark showmanual | xargs apt-mark auto > /dev/null; \
 		[ -z "$savedAptMark" ] || apt-mark manual $savedAptMark; \

--- a/2/debian/Dockerfile
+++ b/2/debian/Dockerfile
@@ -77,7 +77,7 @@ RUN set -eux; \
 # must be some non-amd64 architecture pre-built binaries aren't published for, so let's install some build deps and do-it-all-over-again
 		savedAptMark="$(apt-mark showmanual)"; \
 		apt-get update; \
-		apt-get install -y --no-install-recommends python make gcc g++ libc-dev; \
+		apt-get install -y --no-install-recommends python3 make gcc g++ libc-dev; \
 		rm -rf /var/lib/apt/lists/*; \
 		\
 		gosu node yarn add "sqlite3@$sqlite3Version" --force --build-from-source; \

--- a/3/alpine/Dockerfile
+++ b/3/alpine/Dockerfile
@@ -51,9 +51,9 @@ RUN set -eux; \
 	sqlite3Version="$(node -p 'require("./package.json").optionalDependencies.sqlite3')"; \
 	if ! su-exec node yarn add "sqlite3@$sqlite3Version" --force; then \
 # must be some non-amd64 architecture pre-built binaries aren't published for, so let's install some build deps and do-it-all-over-again
-		apk add --no-cache --virtual .build-deps python3 make gcc g++ libc-dev; \
+		apk add --no-cache --virtual .build-deps g++ gcc libc-dev make python3 vips-dev; \
 		\
-		su-exec node yarn add "sqlite3@$sqlite3Version" --force --build-from-source; \
+		npm_config_python='python3' su-exec node yarn add "sqlite3@$sqlite3Version" --force --build-from-source; \
 		\
 		apk del --no-network .build-deps; \
 	fi; \

--- a/3/alpine/Dockerfile
+++ b/3/alpine/Dockerfile
@@ -51,7 +51,7 @@ RUN set -eux; \
 	sqlite3Version="$(node -p 'require("./package.json").optionalDependencies.sqlite3')"; \
 	if ! su-exec node yarn add "sqlite3@$sqlite3Version" --force; then \
 # must be some non-amd64 architecture pre-built binaries aren't published for, so let's install some build deps and do-it-all-over-again
-		apk add --no-cache --virtual .build-deps python make gcc g++ libc-dev; \
+		apk add --no-cache --virtual .build-deps python3 make gcc g++ libc-dev; \
 		\
 		su-exec node yarn add "sqlite3@$sqlite3Version" --force --build-from-source; \
 		\

--- a/3/debian/Dockerfile
+++ b/3/debian/Dockerfile
@@ -77,10 +77,10 @@ RUN set -eux; \
 # must be some non-amd64 architecture pre-built binaries aren't published for, so let's install some build deps and do-it-all-over-again
 		savedAptMark="$(apt-mark showmanual)"; \
 		apt-get update; \
-		apt-get install -y --no-install-recommends python3 make gcc g++ libc-dev; \
+		apt-get install -y --no-install-recommends g++ gcc libc-dev libvips-dev make python3; \
 		rm -rf /var/lib/apt/lists/*; \
 		\
-		gosu node yarn add "sqlite3@$sqlite3Version" --force --build-from-source; \
+		npm_config_python='python3' gosu node yarn add "sqlite3@$sqlite3Version" --force --build-from-source; \
 		\
 		apt-mark showmanual | xargs apt-mark auto > /dev/null; \
 		[ -z "$savedAptMark" ] || apt-mark manual $savedAptMark; \

--- a/3/debian/Dockerfile
+++ b/3/debian/Dockerfile
@@ -77,7 +77,7 @@ RUN set -eux; \
 # must be some non-amd64 architecture pre-built binaries aren't published for, so let's install some build deps and do-it-all-over-again
 		savedAptMark="$(apt-mark showmanual)"; \
 		apt-get update; \
-		apt-get install -y --no-install-recommends python make gcc g++ libc-dev; \
+		apt-get install -y --no-install-recommends python3 make gcc g++ libc-dev; \
 		rm -rf /var/lib/apt/lists/*; \
 		\
 		gosu node yarn add "sqlite3@$sqlite3Version" --force --build-from-source; \


### PR DESCRIPTION
This should fix the builds on non-`amd64`/`i386` (or at least allow them to get further)

Context:

https://github.com/docker-library/ghost/blob/3e6b329786af2c2bbb8f6c842d328413ffd1bc41/2/alpine/Dockerfile#L52-L54

Current failure mode:
```console
+ su-exec node yarn add sqlite3@4.2.0 --force
...
gyp info using node@12.19.0 | linux | s390x
gyp ERR! find Python 
gyp ERR! find Python Python is not set from command line or npm configuration
gyp ERR! find Python Python is not set from environment variable PYTHON
gyp ERR! find Python checking if \"python\" can be used
gyp ERR! find Python - \"python\" is not in PATH or produced an error
gyp ERR! find Python checking if \"python2\" can be used
gyp ERR! find Python - \"python2\" is not in PATH or produced an error
gyp ERR! find Python checking if \"python3\" can be used
gyp ERR! find Python - \"python3\" is not in PATH or produced an error
gyp ERR! find Python 
gyp ERR! find Python **********************************************************
gyp ERR! find Python You need to install the latest version of Python.
...
+ apk add --no-cache --virtual .build-deps python make gcc g++ libc-dev
fetch http://dl-cdn.alpinelinux.org/alpine/v3.12/main/s390x/APKINDEX.tar.gz
fetch http://dl-cdn.alpinelinux.org/alpine/v3.12/community/s390x/APKINDEX.tar.gz
ERROR: unsatisfiable constraints:
  python (missing):
    required by: .build-deps-20201105.034642[python]
```