### PR TITLE
Exclude "ppc64le" and "s390x" on Alpine variant

### DIFF
--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -94,6 +94,12 @@ for version in "${versions[@]}"; do
 		variantParent="$(awk 'toupper($1) == "FROM" { print $2 }' "$version/$variant/Dockerfile")"
 		variantArches="${parentRepoToArches[$variantParent]}"
 
+		if [ "$variant" = 'alpine' ]; then
+			# ERROR: unsatisfiable constraints:
+			#   vips-dev (missing):
+			variantArches="$(sed -e 's/ ppc64le / /g' -e 's/ s390x / /g' <<<" $variantArches ")"
+		fi
+
 		echo
 		cat <<-EOE
 			Tags: $(join ', ' "${variantAliases[@]}")


### PR DESCRIPTION
The required `vips-dev` package in Alpine does not exist on these architectures:

https://git.alpinelinux.org/aports/tree/community/vips/APKBUILD?id=e48560ae1fec847145847ad9529fa4a21b379a99#n9

```console
+ apk add --no-cache --virtual .build-deps g++ gcc libc-dev make python3 vips-dev
fetch http://dl-cdn.alpinelinux.org/alpine/v3.11/main/s390x/APKINDEX.tar.gz
fetch http://dl-cdn.alpinelinux.org/alpine/v3.11/community/s390x/APKINDEX.tar.gz
ERROR: unsatisfiable constraints:
  vips-dev (missing):
    required by: .build-deps-20201107.000520[vips-dev]
```

FWIW, Debian appears to resolve this by using `--without-orc` on `ppc64le` (https://sources.debian.org/src/vips/8.10.2-1/debian/rules/#L16-L18), and by using `|| true` on the tests for `s390x` (https://sources.debian.org/src/vips/8.10.2-1/debian/rules/#L32-L37).