### PR TITLE
Fix Debian Ghost 4.x Builds With This One Neat Trick!

### DIFF
--- a/4/debian/Dockerfile
+++ b/4/debian/Dockerfile
@@ -80,7 +80,7 @@ RUN set -eux; \
 		apt-get install -y --no-install-recommends g++ gcc libc-dev libvips-dev make python3; \
 		rm -rf /var/lib/apt/lists/*; \
 		\
-		npm_config_python='python3' gosu node yarn add "sqlite3@$sqlite3Version" --force --build-from-source; \
+		npm_config_python='python3' gosu node yarn add "sqlite3@$sqlite3Version" --force --build-from-source --ignore-optional; \
 		\
 		apt-mark showmanual | xargs apt-mark auto > /dev/null; \
 		[ -z "$savedAptMark" ] || apt-mark manual $savedAptMark; \


### PR DESCRIPTION
Fixes the build issue with Debian Ghost 4.x on non-amd64 architectures.

refs https://github.com/docker-library/ghost/issues/256
- add --ignore-optional to sqlite force install so sharp doesn't try and rebuild at the same time

Note: I only tested with linux/arm64 as the platform, but I _think_ this fix should work with any arch that doesn't have a prebuilt binary

(Apologies for the click-baity title, couldn't resist 😛)