### PR TITLE
[FIX] arm64 libvips (broken sqlite build)

### DIFF
--- a/4/alpine/Dockerfile
+++ b/4/alpine/Dockerfile
@@ -51,9 +51,9 @@ RUN set -eux; \
 	sqlite3Version="$(node -p 'require("./package.json").optionalDependencies.sqlite3')"; \
 	if ! su-exec node yarn add "sqlite3@$sqlite3Version" --force; then \
 # must be some non-amd64 architecture pre-built binaries aren't published for, so let's install some build deps and do-it-all-over-again
-		apk add --no-cache --virtual .build-deps g++ gcc libc-dev make python3 vips-dev; \
+		apk add --no-cache --virtual .build-deps g++ gcc libc-dev make python2 vips-dev; \
 		\
-		npm_config_python='python3' su-exec node yarn add "sqlite3@$sqlite3Version" --force --build-from-source; \
+		npm_config_python='python2' su-exec node yarn add "sqlite3@$sqlite3Version" --force --build-from-source; \
 		\
 		apk del --no-network .build-deps; \
 	fi; \

--- a/4/debian/Dockerfile
+++ b/4/debian/Dockerfile
@@ -1,7 +1,7 @@
 # https://docs.ghost.org/faq/node-versions/
 # https://github.com/nodejs/Release (looking for "LTS")
 # https://github.com/TryGhost/Ghost/blob/v4.1.2/package.json#L38
-FROM node:14-buster-slim
+FROM node:14-bullseye-slim
 
 # grab gosu for easy step-down from root
 # https://github.com/tianon/gosu/releases
@@ -77,10 +77,10 @@ RUN set -eux; \
 # must be some non-amd64 architecture pre-built binaries aren't published for, so let's install some build deps and do-it-all-over-again
 		savedAptMark="$(apt-mark showmanual)"; \
 		apt-get update; \
-		apt-get install -y --no-install-recommends g++ gcc libc-dev libvips-dev make python3; \
+		apt-get install -y --no-install-recommends g++ gcc libc-dev libvips-dev make python2; \
 		rm -rf /var/lib/apt/lists/*; \
 		\
-		npm_config_python='python3' gosu node yarn add "sqlite3@$sqlite3Version" --force --build-from-source --ignore-optional; \
+		npm_config_python='python2' gosu node yarn add "sqlite3@$sqlite3Version" --force --build-from-source --ignore-optional; \
 		\
 		apt-mark showmanual | xargs apt-mark auto > /dev/null; \
 		[ -z "$savedAptMark" ] || apt-mark manual $savedAptMark; \


### PR DESCRIPTION
### SUMMARY:
On non-amd64 platforms the 4/*/Dockerfile will fail to install sqlite3 from node, and failover to manually building it. Changes to the node-sqlite3 build scripts now include python2 syntax that causes python3 build errors. This can be fixed by downgrading to python2. Debian support on arm64 necessitates bumping to bullseye for dependency requirements.

The following builds now complete successfully:
- 4/alpine linux/arm64 (docker buildx)
- 4/alpine linux/arm (docker buildx)
- 4/alpine linux/amd64 (native)
- 4/debian linux/arm64 (docker buildx)
- 4/debian linux/arm (docker buildx)
- 4/debian linux/amd64 (native)

This may need more deployment testing of non-arm images.

### CHANGES:
- Downgrades python3 to python2 to support broken sqlite3 build scripts when arm/arm64 fails over to manual build
- Upgrades 4/debian to bullseye for arm64 dependency compatibility

### RELATED:
- fixes #267
  - (tested deployment with 4/alpine on arm64) 
- fixes #264 
  - (tested deployment with 4/alpine on arm64) 