### PR TITLE
Build sharp for non-amd64 architectures

### DIFF
--- a/4/alpine/Dockerfile
+++ b/4/alpine/Dockerfile
@@ -1,7 +1,7 @@
 # https://docs.ghost.org/faq/node-versions/
 # https://github.com/nodejs/Release (looking for "LTS")
 # https://github.com/TryGhost/Ghost/blob/v4.1.2/package.json#L38
-FROM node:14-alpine3.14
+FROM node:14-alpine3.15
 
 # grab su-exec for easy step-down from root
 RUN apk add --no-cache 'su-exec>=0.2'
@@ -49,11 +49,16 @@ RUN set -eux; \
 	cd "$GHOST_INSTALL/current"; \
 # scrape the expected version of sqlite3 directly from Ghost itself
 	sqlite3Version="$(node -p 'require("./package.json").optionalDependencies.sqlite3')"; \
-	if ! su-exec node yarn add "sqlite3@$sqlite3Version" --force; then \
+	sharpVersion="$(node -p 'require("./node_modules/@tryghost/image-transform/package.json").optionalDependencies.sharp')"; \
+	su-exec node yarn add "sqlite3@$sqlite3Version" --force && sqlite3Installed=Y || sqlite3Installed=N; \
+	su-exec node yarn add "sharp@$sharpVersion" --force && sharpInstalled=Y || sharpInstalled=N; \
+	if [ "$sqlite3Installed" = "N" ] || [ "$sharpInstalled" = "N" ]; then \
 # must be some non-amd64 architecture pre-built binaries aren't published for, so let's install some build deps and do-it-all-over-again
+		[ "$sharpInstalled" = "N" ] && apk add --no-cache vips; \
 		apk add --no-cache --virtual .build-deps g++ gcc libc-dev make python2 vips-dev; \
 		\
-		npm_config_python='python2' su-exec node yarn add "sqlite3@$sqlite3Version" --force --build-from-source; \
+		[ "$sqlite3Installed" = "N" ] && npm_config_python='python2' su-exec node yarn add "sqlite3@$sqlite3Version" --force --build-from-source --ignore-optional; \
+		[ "$sharpInstalled" = "N" ] && ( npm_config_python='python2' npm_config_build_from_source=true su-exec node yarn add "sharp@$sharpVersion" || echo "sharp@$sharpVersion: build failed, continuing..." ); \
 		\
 		apk del --no-network .build-deps; \
 	fi; \

--- a/4/debian/Dockerfile
+++ b/4/debian/Dockerfile
@@ -73,24 +73,46 @@ RUN set -eux; \
 	cd "$GHOST_INSTALL/current"; \
 # scrape the expected version of sqlite3 directly from Ghost itself
 	sqlite3Version="$(node -p 'require("./package.json").optionalDependencies.sqlite3')"; \
-	if ! gosu node yarn add "sqlite3@$sqlite3Version" --force; then \
+	sharpVersion="$(node -p 'require("./node_modules/@tryghost/image-transform/package.json").optionalDependencies.sharp')"; \
+	gosu node yarn add "sqlite3@$sqlite3Version" --force && sqlite3Installed=Y || sqlite3Installed=N; \
+	gosu node yarn add "sharp@$sharpVersion" --force && sharpInstalled=Y || sharpInstalled=N; \
+	if [ "$sqlite3Installed" = "N" ] || [ "$sharpInstalled" = "N" ]; then \
 # must be some non-amd64 architecture pre-built binaries aren't published for, so let's install some build deps and do-it-all-over-again
 		savedAptMark="$(apt-mark showmanual)"; \
 		apt-get update; \
-		apt-get install -y --no-install-recommends g++ gcc libc-dev libvips-dev make python2; \
+		apt-get install -y --no-install-recommends g++ gcc libc-dev make python2; \
 		rm -rf /var/lib/apt/lists/*; \
 		\
-		npm_config_python='python2' gosu node yarn add "sqlite3@$sqlite3Version" --force --build-from-source --ignore-optional; \
-		\
+		[ "$sqlite3Installed" = "N" ] && npm_config_python='python2' gosu node yarn add "sqlite3@$sqlite3Version" --force --build-from-source --ignore-optional; \
+		[ "$sqlite3Installed" = "N" ] && \
+			# We need a recent copy of "libvips-dev". We're running Debian bullseye.
+			# So we build the bookworm version of "libvips-dev" against the existing bullseye runtime. This gives us best compatibility.
+			( mkdir -p /tmp/libvips-build; \
+			cd /tmp/libvips-build; \
+			# Add a repo source code entry for Debian bookworm.
+			echo "deb-src http://deb.debian.org/debian bookworm main" >> /etc/apt/sources.list; \
+			apt-get update; \
+			# First we build bookworm "libcgif-dev", a prerequisite for "libvips-dev" that's not in Debian bullseye
+			apt-get build-dep -y libcgif-dev; \
+			apt-get -b source libcgif-dev; \
+			dpkg -i libcgif0_*.deb libcgif-dev_*.deb; \
+			# Next we build bookworm "libvips-dev" against the rest of the bullseye packages.
+			apt-get build-dep -y libvips-dev; \
+			apt-get -b source libvips-dev; \
+			dpkg -i libvips42_*.deb gir1.2-vips-8.0_*.deb libvips-dev_*.deb; \
+			# We've finally got "libvips-dev" installed, now we can build sharp.
+			cd "$GHOST_INSTALL/current"; \
+			npm_config_python='python2' npm_config_build_from_source=true gosu node yarn add "sharp@$sharpVersion"; ) || echo "sharp@$sharpVersion: build failed, continuing..."; \
 		apt-mark showmanual | xargs apt-mark auto > /dev/null; \
 		[ -z "$savedAptMark" ] || apt-mark manual $savedAptMark; \
+		[ "$sharpInstalled" = "N" ] && apt-mark manual libvips42; \
 		apt-get purge -y --auto-remove; \
 	fi; \
 	\
 	gosu node yarn cache clean; \
 	gosu node npm cache clean --force; \
 	npm cache clean --force; \
-	rm -rv /tmp/yarn* /tmp/v8*
+	rm -rv /tmp/yarn* /tmp/v8* /tmp/libvips-build
 
 WORKDIR $GHOST_INSTALL
 VOLUME $GHOST_CONTENT


### PR DESCRIPTION
On non-amd64 architectures, the default version of `sharp` may not automatically install due to a missing copy of `libvips`. This is referred to in PR #281 and issues #264 and #267. However whilst #281 fixes the images so they build and run, `sharp` may still not be built. It's an optional dependency and ghost works fine without it.

This PR is to get `libvips` installed, and `sharp` installed and built.

On Alpine, we upgrade to 3.15 (was 3.14). This gives us libvips 8.12.1-r0 ([link to Alpine package search](https://pkgs.alpinelinux.org/packages?name=vips&branch=v3.15)) which is sufficient to build the current dependency version of sharp (0.29.0).

The main caveat of the Alpine change is, we'll be upgrading from 3.14 to 3.15. This may require across-the-board testing.

On Debian, we currently use the bullseye image version. However the bullseye version of libvips-dev (8.10.5-2) isn't recent enough ([link to Debian package search](https://packages.debian.org/search?keywords=libvips-dev&searchon=names&suite=all&section=all)). So we download and build libvips-dev from Debian bookworm, which brings us version 8.12.1-1. (We also download and build libcgif-dev, since that prerequisite isn't available in bullseye.)

Note that on Debian we download and build the packages from source, targeting the bullseye runtime. This is likely to give better compatibility versus simply installing the official bookworm packages, which may require updated components.

I've only tested this on my 32-bit Raspberry Pi (armv7). Happy to take advice on how to get this PR ready for merging. Thanks!