### PR TITLE
Update to 4.43.0

### DIFF
--- a/4/alpine/Dockerfile
+++ b/4/alpine/Dockerfile
@@ -20,7 +20,7 @@ RUN set -eux; \
 ENV GHOST_INSTALL /var/lib/ghost
 ENV GHOST_CONTENT /var/lib/ghost/content
 
-ENV GHOST_VERSION 4.43.0
+ENV GHOST_VERSION 4.43.1
 
 RUN set -eux; \
 	mkdir -p "$GHOST_INSTALL"; \

--- a/4/alpine/Dockerfile
+++ b/4/alpine/Dockerfile
@@ -20,7 +20,7 @@ RUN set -eux; \
 ENV GHOST_INSTALL /var/lib/ghost
 ENV GHOST_CONTENT /var/lib/ghost/content
 
-ENV GHOST_VERSION 4.41.3
+ENV GHOST_VERSION 4.43.0
 
 RUN set -eux; \
 	mkdir -p "$GHOST_INSTALL"; \
@@ -48,12 +48,14 @@ RUN set -eux; \
 # see https://github.com/TryGhost/Ghost/pull/7677 for more details
 	cd "$GHOST_INSTALL/current"; \
 # scrape the expected version of sqlite3 directly from Ghost itself
-	sqlite3Version="$(node -p 'require("./package.json").optionalDependencies.sqlite3')"; \
-	if ! su-exec node yarn add "sqlite3@$sqlite3Version" --force; then \
+	sqlite3Version="$(node -p 'require("./package.json").optionalDependencies["@vscode/sqlite3"]')"; \
+	[ -n "$sqlite3Version" ]; \
+	[ "$sqlite3Version" != 'undefined' ]; \
+	if ! su-exec node yarn add "@vscode/sqlite3@$sqlite3Version" --force; then \
 # must be some non-amd64 architecture pre-built binaries aren't published for, so let's install some build deps and do-it-all-over-again
 		apk add --no-cache --virtual .build-deps g++ gcc libc-dev make python2 vips-dev; \
 		\
-		npm_config_python='python2' su-exec node yarn add "sqlite3@$sqlite3Version" --force --build-from-source; \
+		npm_config_python='python2' su-exec node yarn add "@vscode/sqlite3@$sqlite3Version" --force --build-from-source; \
 		\
 		apk del --no-network .build-deps; \
 	fi; \

--- a/4/debian/Dockerfile
+++ b/4/debian/Dockerfile
@@ -44,7 +44,7 @@ RUN set -eux; \
 ENV GHOST_INSTALL /var/lib/ghost
 ENV GHOST_CONTENT /var/lib/ghost/content
 
-ENV GHOST_VERSION 4.43.0
+ENV GHOST_VERSION 4.43.1
 
 RUN set -eux; \
 	mkdir -p "$GHOST_INSTALL"; \

--- a/4/debian/Dockerfile
+++ b/4/debian/Dockerfile
@@ -44,7 +44,7 @@ RUN set -eux; \
 ENV GHOST_INSTALL /var/lib/ghost
 ENV GHOST_CONTENT /var/lib/ghost/content
 
-ENV GHOST_VERSION 4.41.3
+ENV GHOST_VERSION 4.43.0
 
 RUN set -eux; \
 	mkdir -p "$GHOST_INSTALL"; \
@@ -72,15 +72,17 @@ RUN set -eux; \
 # see https://github.com/TryGhost/Ghost/pull/7677 for more details
 	cd "$GHOST_INSTALL/current"; \
 # scrape the expected version of sqlite3 directly from Ghost itself
-	sqlite3Version="$(node -p 'require("./package.json").optionalDependencies.sqlite3')"; \
-	if ! gosu node yarn add "sqlite3@$sqlite3Version" --force; then \
+	sqlite3Version="$(node -p 'require("./package.json").optionalDependencies["@vscode/sqlite3"]')"; \
+	[ -n "$sqlite3Version" ]; \
+	[ "$sqlite3Version" != 'undefined' ]; \
+	if ! gosu node yarn add "@vscode/sqlite3@$sqlite3Version" --force; then \
 # must be some non-amd64 architecture pre-built binaries aren't published for, so let's install some build deps and do-it-all-over-again
 		savedAptMark="$(apt-mark showmanual)"; \
 		apt-get update; \
 		apt-get install -y --no-install-recommends g++ gcc libc-dev libvips-dev make python2; \
 		rm -rf /var/lib/apt/lists/*; \
 		\
-		npm_config_python='python2' gosu node yarn add "sqlite3@$sqlite3Version" --force --build-from-source --ignore-optional; \
+		npm_config_python='python2' gosu node yarn add "@vscode/sqlite3@$sqlite3Version" --force --build-from-source --ignore-optional; \
 		\
 		apt-mark showmanual | xargs apt-mark auto > /dev/null; \
 		[ -z "$savedAptMark" ] || apt-mark manual $savedAptMark; \


### PR DESCRIPTION
This also requires us to account for https://github.com/TryGhost/Ghost/commit/86680cb2079fa24037f96d163dc05e30f83846dd

(Unfortunately, this means we also get to build the `sqlite3` gem from source on every architecture since it doesn't appear that `@vscode/sqlite3` is pre-built anywhere. :disappointed:)