### PR TITLE
Update v4 to v4.48.2, v5 to v5.2.3

### DIFF
--- a/4/alpine/Dockerfile
+++ b/4/alpine/Dockerfile
@@ -20,7 +20,7 @@ RUN set -eux; \
 ENV GHOST_INSTALL /var/lib/ghost
 ENV GHOST_CONTENT /var/lib/ghost/content
 
-ENV GHOST_VERSION 4.48.1
+ENV GHOST_VERSION 4.48.2
 
 RUN set -eux; \
 	mkdir -p "$GHOST_INSTALL"; \

--- a/4/alpine/Dockerfile
+++ b/4/alpine/Dockerfile
@@ -1,7 +1,7 @@
 # https://docs.ghost.org/faq/node-versions/
 # https://github.com/nodejs/Release (looking for "LTS")
 # https://github.com/TryGhost/Ghost/blob/v4.1.2/package.json#L38
-FROM node:14-alpine3.14
+FROM node:14-alpine3.15
 
 # grab su-exec for easy step-down from root
 RUN apk add --no-cache 'su-exec>=0.2'

--- a/4/debian/Dockerfile
+++ b/4/debian/Dockerfile
@@ -44,7 +44,7 @@ RUN set -eux; \
 ENV GHOST_INSTALL /var/lib/ghost
 ENV GHOST_CONTENT /var/lib/ghost/content
 
-ENV GHOST_VERSION 4.48.1
+ENV GHOST_VERSION 4.48.2
 
 RUN set -eux; \
 	mkdir -p "$GHOST_INSTALL"; \

--- a/5/alpine/Dockerfile
+++ b/5/alpine/Dockerfile
@@ -20,7 +20,7 @@ RUN set -eux; \
 ENV GHOST_INSTALL /var/lib/ghost
 ENV GHOST_CONTENT /var/lib/ghost/content
 
-ENV GHOST_VERSION 5.2.2
+ENV GHOST_VERSION 5.2.3
 
 RUN set -eux; \
 	mkdir -p "$GHOST_INSTALL"; \

--- a/5/debian/Dockerfile
+++ b/5/debian/Dockerfile
@@ -44,7 +44,7 @@ RUN set -eux; \
 ENV GHOST_INSTALL /var/lib/ghost
 ENV GHOST_CONTENT /var/lib/ghost/content
 
-ENV GHOST_VERSION 5.2.2
+ENV GHOST_VERSION 5.2.3
 
 RUN set -eux; \
 	mkdir -p "$GHOST_INSTALL"; \


### PR DESCRIPTION
Release patched versions for vulnerability https://github.com/TryGhost/Ghost/security/advisories/GHSA-7v28-g2pq-ggg8