### PR TITLE
BREAKING CHANGE: Switch from sqlite3 to MySQL by default

### DIFF
--- a/5/alpine/Dockerfile
+++ b/5/alpine/Dockerfile
@@ -28,7 +28,7 @@ RUN set -eux; \
 	\
 	apkDel=; \
 	\
-	installCmd='su-exec node ghost install "$GHOST_VERSION" --db sqlite3 --no-prompt --no-stack --no-setup --dir "$GHOST_INSTALL"'; \
+	installCmd='su-exec node ghost install "$GHOST_VERSION" --db mysql --dbhost mysql --no-prompt --no-stack --no-setup --dir "$GHOST_INSTALL"'; \
 	if ! eval "$installCmd"; then \
 		virtual='.build-deps-ghost'; \
 		apkDel="$apkDel $virtual"; \
@@ -38,7 +38,7 @@ RUN set -eux; \
 	\
 # Tell Ghost to listen on all ips and not prompt for additional configuration
 	cd "$GHOST_INSTALL"; \
-	su-exec node ghost config --ip '::' --port 2368 --no-prompt --db sqlite3 --url http://localhost:2368 --dbpath "$GHOST_CONTENT/data/ghost.db"; \
+	su-exec node ghost config --no-prompt --ip '::' --port 2368 --url 'http://localhost:2368'; \
 	su-exec node ghost config paths.contentPath "$GHOST_CONTENT"; \
 	\
 # make a config.json symlink for NODE_ENV=development (and sanity check that it's correct)

--- a/5/debian/Dockerfile
+++ b/5/debian/Dockerfile
@@ -53,7 +53,7 @@ RUN set -eux; \
 	savedAptMark="$(apt-mark showmanual)"; \
 	aptPurge=; \
 	\
-	installCmd='gosu node ghost install "$GHOST_VERSION" --db sqlite3 --no-prompt --no-stack --no-setup --dir "$GHOST_INSTALL"'; \
+	installCmd='gosu node ghost install "$GHOST_VERSION" --db mysql --dbhost mysql --no-prompt --no-stack --no-setup --dir "$GHOST_INSTALL"'; \
 	if ! eval "$installCmd"; then \
 		aptPurge=1; \
 		apt-get update; \
@@ -63,7 +63,7 @@ RUN set -eux; \
 	\
 # Tell Ghost to listen on all ips and not prompt for additional configuration
 	cd "$GHOST_INSTALL"; \
-	gosu node ghost config --ip '::' --port 2368 --no-prompt --db sqlite3 --url http://localhost:2368 --dbpath "$GHOST_CONTENT/data/ghost.db"; \
+	gosu node ghost config --no-prompt --ip '::' --port 2368 --url 'http://localhost:2368'; \
 	gosu node ghost config paths.contentPath "$GHOST_CONTENT"; \
 	\
 # make a config.json symlink for NODE_ENV=development (and sanity check that it's correct)


### PR DESCRIPTION
Fixes #310

The intent is to merge this breaking change to coincide with the 5.9 upstream Ghost release so that we have a clean place to point users back to (https://github.com/docker-library/ghost/issues/310#issuecomment-1208330219).

Here's a full diff of the generated configuration files:

```diff
$ diff -u <(docker run --rm ghost:5 cat config.production.json) <(docker run --rm 02801f1260e3 cat config.production.json)
--- /dev/fd/63	2022-08-08 15:13:53.049985157 -0700
+++ /dev/fd/62	2022-08-08 15:13:53.053985192 -0700
@@ -4,12 +4,6 @@
     "port": 2368,
     "host": "::"
   },
-  "database": {
-    "client": "sqlite3",
-    "connection": {
-      "filename": "/var/lib/ghost/content/data/ghost.db"
-    }
-  },
   "mail": {
     "transport": "Direct"
   },
```

```diff
$ diff -u <(docker run --rm ghost:5-alpine cat config.production.json) <(docker run --rm 8cb6b6c0d885 cat config.production.json)
--- /dev/fd/63	2022-08-08 15:16:02.807350683 -0700
+++ /dev/fd/62	2022-08-08 15:16:02.807350683 -0700
@@ -4,12 +4,6 @@
     "port": 2368,
     "host": "::"
   },
-  "database": {
-    "client": "sqlite3",
-    "connection": {
-      "filename": "/var/lib/ghost/content/data/ghost.db"
-    }
-  },
   "mail": {
     "transport": "Direct"
   },
```

cc @ErisDS

One thing I'm not sure about is whether we should still include `--db mysql` in the `ghost config` line so that we get an explicit `client: mysql` in that configuration.  Further, I think it would probably also make sense to include `--dbhost mysql` so that we also get `host: mysql` (instead of the default of "localhost" which isn't terribly useful in a container setup).  Users would still need to supply their username/password/database, but at least this would be a starting point?  Maybe even a default database of "ghost" or something?  I don't want to make too many choices here that might end up in the same place as #310 :sweat_smile: