### PR TITLE
Switch back to python3 since python2 is not available in alpine 3.16

### DIFF
--- a/4/alpine/Dockerfile
+++ b/4/alpine/Dockerfile
@@ -53,9 +53,9 @@ RUN set -eux; \
 	[ "$sqlite3Version" != 'undefined' ]; \
 	if ! su-exec node yarn add "sqlite3@$sqlite3Version" --force; then \
 # must be some non-amd64 architecture pre-built binaries aren't published for, so let's install some build deps and do-it-all-over-again
-		apk add --no-cache --virtual .build-deps g++ gcc libc-dev make python2 vips-dev; \
+		apk add --no-cache --virtual .build-deps g++ gcc libc-dev make python3 vips-dev; \
 		\
-		npm_config_python='python2' su-exec node yarn add "sqlite3@$sqlite3Version" --force --build-from-source; \
+		su-exec node yarn add "sqlite3@$sqlite3Version" --force --build-from-source; \
 		\
 		apk del --no-network .build-deps; \
 	fi; \

--- a/4/debian/Dockerfile
+++ b/4/debian/Dockerfile
@@ -79,10 +79,10 @@ RUN set -eux; \
 # must be some non-amd64 architecture pre-built binaries aren't published for, so let's install some build deps and do-it-all-over-again
 		savedAptMark="$(apt-mark showmanual)"; \
 		apt-get update; \
-		apt-get install -y --no-install-recommends g++ gcc libc-dev libvips-dev make python2; \
+		apt-get install -y --no-install-recommends g++ gcc libc-dev libvips-dev make python3; \
 		rm -rf /var/lib/apt/lists/*; \
 		\
-		npm_config_python='python2' gosu node yarn add "sqlite3@$sqlite3Version" --force --build-from-source; \
+		gosu node yarn add "sqlite3@$sqlite3Version" --force --build-from-source; \
 		\
 		apt-mark showmanual | xargs apt-mark auto > /dev/null; \
 		[ -z "$savedAptMark" ] || apt-mark manual $savedAptMark; \


### PR DESCRIPTION
The "missing" `python2` in Alpine 3.16 is currently causing the Ghost 4 to fail to build on `arm32vX`.

(Dropping `python2` in Debian as well to keep them consistent with each other)