### PR TITLE
Add Austin to the official "Maintainers:" block

### DIFF
--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -57,7 +57,8 @@ cat <<-EOH
 # this file is generated via https://github.com/docker-library/ghost/blob/$(fileCommit "$self")/$self
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
-             Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
+             Joseph Ferguson <yosifkit@gmail.com> (@yosifkit),
+             Austin Burdine <austin@acburdine.me> (@acburdine)
 GitRepo: https://github.com/docker-library/ghost.git
 EOH
 


### PR DESCRIPTION
@acburdine any objection to being "officially" listed here? (no hard feelings either way, but I figured a pull request was an effective way to ask! :smile:)

The practical end result of this is that you'll get a "CC" on all the official-images update PRs and you'll get an @-reference any time there's a change that affects the `ghost` image in other ways (see https://github.com/docker-library/official-images/pull/13577#issuecomment-1324292585 for a recent example that didn't affect `ghost` but shows you the kind of thing that we use this for).