### PR TITLE
Alpine bump to supported node image

### DIFF
--- a/5/alpine/Dockerfile
+++ b/5/alpine/Dockerfile
@@ -1,7 +1,7 @@
 # https://docs.ghost.org/faq/node-versions/
 # https://github.com/nodejs/Release (looking for "LTS")
 # https://github.com/TryGhost/Ghost/blob/v5.0.0/package.json#L54
-FROM node:16-alpine3.16
+FROM node:16-alpine3.17
 
 # grab su-exec for easy step-down from root
 RUN apk add --no-cache 'su-exec>=0.2'


### PR DESCRIPTION
Minimal Alpine bump to get to an active version of `node:16-alpine*`.

Do we need to address https://github.com/docker-library/ghost/pull/384 before this?