### PR TITLE
Bump ghost version to 5.50.4

### DIFF
--- a/5/alpine/Dockerfile
+++ b/5/alpine/Dockerfile
@@ -20,7 +20,7 @@ RUN set -eux; \
 ENV GHOST_INSTALL /var/lib/ghost
 ENV GHOST_CONTENT /var/lib/ghost/content
 
-ENV GHOST_VERSION 5.49.3
+ENV GHOST_VERSION 5.50.4
 
 RUN set -eux; \
 	mkdir -p "$GHOST_INSTALL"; \

--- a/5/debian/Dockerfile
+++ b/5/debian/Dockerfile
@@ -44,7 +44,7 @@ RUN set -eux; \
 ENV GHOST_INSTALL /var/lib/ghost
 ENV GHOST_CONTENT /var/lib/ghost/content
 
-ENV GHOST_VERSION 5.49.3
+ENV GHOST_VERSION 5.50.4
 
 RUN set -eux; \
 	mkdir -p "$GHOST_INSTALL"; \


### PR DESCRIPTION
v5.50.4  was released in the meantime. https://github.com/TryGhost/Ghost/releases/tag/v5.50.4 

It's 5.50 with the bugfixing and no new features.

I believe this package should exist. Later, I'll also propose 5.51