### PR TITLE
Bump node to 18 since 16 is EOL later this month

### DIFF
--- a/5/alpine/Dockerfile
+++ b/5/alpine/Dockerfile
@@ -1,7 +1,6 @@
 # https://docs.ghost.org/faq/node-versions/
 # https://github.com/nodejs/Release (looking for "LTS")
-# https://github.com/TryGhost/Ghost/blob/v5.0.0/package.json#L54
-FROM node:16-alpine3.17
+FROM node:18-alpine3.17
 
 # grab su-exec for easy step-down from root
 RUN apk add --no-cache 'su-exec>=0.2'

--- a/5/debian/Dockerfile
+++ b/5/debian/Dockerfile
@@ -1,7 +1,6 @@
 # https://docs.ghost.org/faq/node-versions/
 # https://github.com/nodejs/Release (looking for "LTS")
-# https://github.com/TryGhost/Ghost/blob/v4.1.2/package.json#L38
-FROM node:16-bullseye-slim
+FROM node:18-bullseye-slim
 
 # grab gosu for easy step-down from root
 # https://github.com/tianon/gosu/releases


### PR DESCRIPTION
See also https://docs.ghost.org/faq/node-versions/ which now recommends Node 18.

Related Node image EOL PR: https://github.com/nodejs/docker-node/pull/1959

(Not changing the OS versions right now, since that is more likely to break users.)