### PR TITLE
Add sharp module building

### DIFF
--- a/5/alpine/Dockerfile
+++ b/5/alpine/Dockerfile
@@ -70,8 +70,7 @@ RUN set -eux; \
 # must be some non-amd64 architecture pre-built binaries aren't published for, so let's install some build deps and do-it-all-over-again
 			virtualPackages='g++ make python3'; \
 			case "$package" in \
-				# TODO sharp@*) virtualPackages="$virtualPackages pkgconf vips-dev"; \
-				sharp@*) echo >&2 "sorry: libvips 8.12.1 in Alpine 3.15 is not new enough (8.12.2+) for sharp 0.30 😞"; continue ;; \
+				sharp@*) virtualPackages="$virtualPackages pkgconf vips-dev"; \
 			esac; \
 			virtual=".build-deps-${package%%@*}"; \
 			apkDel="$apkDel $virtual"; \


### PR DESCRIPTION
Alpine 3.17 lib-vips is new enough for sharp

https://github.com/TryGhost/Ghost/blob/v5.65.1/yarn.lock#L28340-L28341
https://github.com/lovell/sharp/blob/v0.30.7/package.json#L157
https://pkgs.alpinelinux.org/packages?name=vips-dev&branch=v3.17

⬆️ this is a lot of manual checking to see which version of `sharp` that Ghost requires, and then which version of `libvips` that `sharp` requires, and then checking if that is available in the Alpine release we are on. I'd rather have some automation (in the Dockerfile?) to check these assumptions before just adding `sharp` back to the `build-from-source` deps.

Closes https://github.com/docker-library/ghost/pull/293