### PR TITLE
Update to Alpine 3.20

### DIFF
--- a/5/alpine/Dockerfile
+++ b/5/alpine/Dockerfile
@@ -1,6 +1,6 @@
 # https://docs.ghost.org/faq/node-versions/
 # https://github.com/nodejs/Release (looking for "LTS")
-FROM node:18-alpine3.19
+FROM node:18-alpine3.20
 
 RUN apk add --no-cache \
 # add "bash" for "[["


### PR DESCRIPTION
I wanted to go to Alpine 3.21, but that's not supported by Node.js 18 (ATM?)