### PR TITLE
Add missing distutils to fix builds on some architectures

### DIFF
--- a/5/alpine/Dockerfile
+++ b/5/alpine/Dockerfile
@@ -96,7 +96,7 @@ RUN set -eux; \
 		installCmd='gosu node yarn add "$package" --force'; \
 		if ! eval "$installCmd"; then \
 # must be some non-amd64 architecture pre-built binaries aren't published for, so let's install some build deps and do-it-all-over-again
-			virtualPackages='g++ make python3'; \
+			virtualPackages='g++ make python3 py3-setuptools'; \
 			case "$package" in \
 				# TODO sharp@*) virtualPackages="$virtualPackages pkgconf vips-dev"; \
 				sharp@*) echo >&2 "sorry: libvips 8.12.1 in Alpine 3.15 is not new enough (8.12.2+) for sharp 0.30 😞"; continue ;; \


### PR DESCRIPTION
Like arm32v7 and arm32v6

```console
  File "/var/lib/ghost/versions/5.104.2/node_modules/node-gyp/gyp/pylib/gyp/input.py", line 19, in <module>
    from distutils.version import StrictVersion
ModuleNotFoundError: No module named 'distutils'
```

This broke because Alpine 3.20 ([bump](https://github.com/docker-library/ghost/pull/425)) is using Python 3.12. So, related to https://github.com/docker-library/python/issues/952; `setuptools` (and `distutils`) are not included by default in Python 3.12+.