### PR TITLE
Update Dockerfile base image alpine3.20->alpine3.21

### DIFF
--- a/5/alpine/Dockerfile
+++ b/5/alpine/Dockerfile
@@ -1,6 +1,6 @@
 # https://docs.ghost.org/faq/node-versions/
 # https://github.com/nodejs/Release (looking for "LTS")
-FROM node:18-alpine3.20
+FROM node:18-alpine3.21
 
 RUN apk add --no-cache \
 # add "bash" for "[["


### PR DESCRIPTION
Just a base image bump to the latest. I was looking on the security scans of the image and there a quite few. I'm providing this version bump and trying to investigate how to resolve serious ones.