### PR TITLE
Add support for docker compose secrets

### DIFF
--- a/5/alpine/docker-entrypoint.sh
+++ b/5/alpine/docker-entrypoint.sh
@@ -1,6 +1,37 @@
 #!/bin/bash
 set -e
 
+# from the mysql 8.0 docker-entrypoint.sh, with minor modifications to fit ghost's patterns
+# usage: file_env VAR [DEFAULT]
+#    ie: file_env 'XYZ_DB_PASSWORD' 'example'
+# (will allow for "$XYZ_DB_PASSWORD_FILE" to fill in the value of
+#  "$XYZ_DB_PASSWORD" from a file, especially for Docker's secrets feature)
+file_env() {
+	local var="$1"
+	local fileVar="${var}_file"
+	local def="${2:-}"
+	if [ "${!var:-}" ] && [ "${!fileVar:-}" ]; then
+		echo "Both $var and $fileVar are set (but are exclusive)"
+		return 1
+	fi
+	local val="$def"
+	if [ "${!var:-}" ]; then
+		val="${!var}"
+	elif [ "${!fileVar:-}" ]; then
+		val="$(< "${!fileVar}")"
+	fi
+	export "$var"="$val"
+	unset "$fileVar"
+}
+
+# Initialize values that might usefully be stored in a file
+file_env 'database__connection__host'
+file_env 'database__connection__user'
+file_env 'database__connection__password'
+file_env 'database__connection__database'
+file_env 'mail__auth__user'
+file_env 'mail__auth__pass'
+
 # allow the container to be started with `--user`
 if [[ "$*" == node*current/index.js* ]] && [ "$(id -u)" = '0' ]; then
 	find "$GHOST_CONTENT" \! -user node -exec chown node '{}' +

--- a/5/debian/docker-entrypoint.sh
+++ b/5/debian/docker-entrypoint.sh
@@ -1,6 +1,37 @@
 #!/bin/bash
 set -e
 
+# from the mysql 8.0 docker-entrypoint.sh, with minor modifications to fit ghost's patterns
+# usage: file_env VAR [DEFAULT]
+#    ie: file_env 'XYZ_DB_PASSWORD' 'example'
+# (will allow for "$XYZ_DB_PASSWORD_FILE" to fill in the value of
+#  "$XYZ_DB_PASSWORD" from a file, especially for Docker's secrets feature)
+file_env() {
+	local var="$1"
+	local fileVar="${var}_file"
+	local def="${2:-}"
+	if [ "${!var:-}" ] && [ "${!fileVar:-}" ]; then
+		echo "Both $var and $fileVar are set (but are exclusive)"
+		return 1
+	fi
+	local val="$def"
+	if [ "${!var:-}" ]; then
+		val="${!var}"
+	elif [ "${!fileVar:-}" ]; then
+		val="$(< "${!fileVar}")"
+	fi
+	export "$var"="$val"
+	unset "$fileVar"
+}
+
+# Initialize values that might usefully be stored in a file
+file_env 'database__connection__host'
+file_env 'database__connection__user'
+file_env 'database__connection__password'
+file_env 'database__connection__database'
+file_env 'mail__auth__user'
+file_env 'mail__auth__pass'
+
 # allow the container to be started with `--user`
 if [[ "$*" == node*current/index.js* ]] && [ "$(id -u)" = '0' ]; then
 	find "$GHOST_CONTENT" \! -user node -exec chown node '{}' +


### PR DESCRIPTION
This PR fixes #429.

Docker Compose supports [secrets](https://docs.docker.com/compose/how-tos/use-secrets/) through mounting files in `/run/secrets` with appropriate permissions.

This is safer than passing them on the command line or directly through environment variables as it avoids the risk of the values showing up in execution history or logs.

Some other docker containers such as [MySQL](https://hub.docker.com/_/mysql) support this through the use of environment variable with `_FILE` appended, allowing for the variable to be set from a file rather than directly.

I have copied the same logic from the MySQL `docker-entrypoint.sh`, instead choosing to append `_file` as it fits Ghost's config variables better.

I have tested this with my own setup by swapping out the `docker-entrypoint.sh` file in docker compose, and selected the following variables for `_file` support:

- `database__connection__host`
- `database__connection__user`
- `database__connection__password`
- `database__connection__database`
- `mail__auth__user`
- `mail__auth__pass`

I hope this is useful to someone else, and I don't believe it adds unnecessary complexity to the containers, or removes any existing functionality.