### PR TITLE
Update to Alpine 3.22

### DIFF
--- a/5/alpine/Dockerfile
+++ b/5/alpine/Dockerfile
@@ -1,6 +1,6 @@
 # https://docs.ghost.org/faq/node-versions/
 # https://github.com/nodejs/Release (looking for "LTS")
-FROM node:20-alpine3.21
+FROM node:20-alpine3.22
 
 RUN apk add --no-cache \
 # add "bash" for "[["


### PR DESCRIPTION
Depends on Alpine 3.22 support in the Node.js image ~~(no PR for that exists yet)~~: https://github.com/nodejs/docker-node/pull/2245