### PR TITLE
Add 6.0.0-alpha.1

### DIFF
--- a/6-rc/alpine/Dockerfile
+++ b/6-rc/alpine/Dockerfile
@@ -1,0 +1,129 @@
+# https://docs.ghost.org/faq/node-versions/
+# https://github.com/nodejs/Release (looking for "LTS")
+FROM node:22-alpine3.22
+
+RUN apk add --no-cache \
+# add "bash" for "[["
+		bash
+
+# grab gosu for easy step-down from root
+# https://github.com/tianon/gosu/releases
+ENV GOSU_VERSION 1.17
+RUN set -eux; \
+	\
+	apk add --no-cache --virtual .gosu-deps \
+		ca-certificates \
+		dpkg \
+		gnupg \
+	; \
+	\
+	dpkgArch="$(dpkg --print-architecture | awk -F- '{ print $NF }')"; \
+	wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch"; \
+	wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch.asc"; \
+	\
+# verify the signature
+	export GNUPGHOME="$(mktemp -d)"; \
+	gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4; \
+	gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu; \
+	gpgconf --kill all; \
+	rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc; \
+	\
+# clean up fetch dependencies
+	apk del --no-network .gosu-deps; \
+	\
+	chmod +x /usr/local/bin/gosu; \
+# verify that the binary works
+	gosu --version; \
+	gosu nobody true
+RUN set -eux; ln -svf gosu /usr/local/bin/su-exec; su-exec nobody true # backwards compatibility (TODO remove in Ghost 6+)
+
+ENV NODE_ENV production
+
+ENV GHOST_CLI_VERSION 1.27.1
+RUN set -eux; \
+	npm install -g "ghost-cli@$GHOST_CLI_VERSION"; \
+	npm cache clean --force
+
+ENV GHOST_INSTALL /var/lib/ghost
+ENV GHOST_CONTENT /var/lib/ghost/content
+
+ENV GHOST_VERSION 6.0.0-alpha.1
+
+RUN set -eux; \
+	mkdir -p "$GHOST_INSTALL"; \
+	chown node:node "$GHOST_INSTALL"; \
+	\
+	apkDel=; \
+	\
+	installCmd='gosu node ghost install "$GHOST_VERSION" --db mysql --dbhost mysql --no-prompt --no-stack --no-setup --dir "$GHOST_INSTALL"'; \
+	case "$GHOST_VERSION" in *-alpha* | *-beta* | *-rc*) installCmd="$installCmd --channel next" ;; esac; \
+	if ! eval "$installCmd"; then \
+		virtual='.build-deps-ghost'; \
+		apkDel="$apkDel $virtual"; \
+		apk add --no-cache --virtual "$virtual" g++ linux-headers make python3; \
+		eval "$installCmd"; \
+	fi; \
+	\
+# Tell Ghost to listen on all ips and not prompt for additional configuration
+	cd "$GHOST_INSTALL"; \
+	gosu node ghost config --no-prompt --ip '::' --port 2368 --url 'http://localhost:2368'; \
+	gosu node ghost config paths.contentPath "$GHOST_CONTENT"; \
+	\
+# make a config.json symlink for NODE_ENV=development (and sanity check that it's correct)
+	gosu node ln -s config.production.json "$GHOST_INSTALL/config.development.json"; \
+	readlink -f "$GHOST_INSTALL/config.development.json"; \
+	\
+# need to save initial content for pre-seeding empty volumes
+	mv "$GHOST_CONTENT" "$GHOST_INSTALL/content.orig"; \
+	mkdir -p "$GHOST_CONTENT"; \
+	chown node:node "$GHOST_CONTENT"; \
+	chmod 1777 "$GHOST_CONTENT"; \
+	\
+# force install a few extra packages manually since they're "optional" dependencies
+# (which means that if it fails to install, like on ARM/ppc64le/s390x, the failure will be silently ignored and thus turn into a runtime error instead)
+# see https://github.com/TryGhost/Ghost/pull/7677 for more details
+	cd "$GHOST_INSTALL/current"; \
+# scrape the expected versions directly from Ghost/dependencies
+	packages="$(node -p ' \
+		var ghost = require("./package.json"); \
+		var transform = require("./node_modules/@tryghost/image-transform/package.json"); \
+		[ \
+			"sharp@" + transform.optionalDependencies["sharp"], \
+			"sqlite3@" + ghost.optionalDependencies["sqlite3"], \
+		].join(" ") \
+	')"; \
+	if echo "$packages" | grep 'undefined'; then exit 1; fi; \
+	for package in $packages; do \
+		installCmd='gosu node yarn add "$package" --force'; \
+		if ! eval "$installCmd"; then \
+# must be some non-amd64 architecture pre-built binaries aren't published for, so let's install some build deps and do-it-all-over-again
+			virtualPackages='g++ make python3 py3-setuptools'; \
+			case "$package" in \
+				# TODO sharp@*) virtualPackages="$virtualPackages pkgconf vips-dev"; \
+				sharp@*) echo >&2 "sorry: libvips 8.12.1 in Alpine 3.15 is not new enough (8.12.2+) for sharp 0.30 😞"; continue ;; \
+			esac; \
+			virtual=".build-deps-${package%%@*}"; \
+			apkDel="$apkDel $virtual"; \
+			apk add --no-cache --virtual "$virtual" $virtualPackages; \
+			\
+			eval "$installCmd --build-from-source"; \
+		fi; \
+	done; \
+	\
+	if [ -n "$apkDel" ]; then \
+		apk del --no-network $apkDel; \
+	fi; \
+	\
+	gosu node yarn cache clean; \
+	gosu node npm cache clean --force; \
+	npm cache clean --force; \
+	rm -rv /tmp/yarn* /tmp/v8*
+
+WORKDIR $GHOST_INSTALL
+VOLUME $GHOST_CONTENT
+
+COPY docker-entrypoint.sh /usr/local/bin
+ENTRYPOINT ["docker-entrypoint.sh"]
+
+EXPOSE 2368
+CMD ["node", "current/index.js"]

--- a/6-rc/alpine/docker-entrypoint.sh
+++ b/6-rc/alpine/docker-entrypoint.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+set -e
+
+# allow the container to be started with `--user`
+if [[ "$*" == node*current/index.js* ]] && [ "$(id -u)" = '0' ]; then
+	find "$GHOST_CONTENT" \! -user node -exec chown node '{}' +
+	exec gosu node "$BASH_SOURCE" "$@"
+fi
+
+if [[ "$*" == node*current/index.js* ]]; then
+	baseDir="$GHOST_INSTALL/content.orig"
+	for src in "$baseDir"/*/ "$baseDir"/themes/*; do
+		src="${src%/}"
+		target="$GHOST_CONTENT/${src#$baseDir/}"
+		mkdir -p "$(dirname "$target")"
+		if [ ! -e "$target" ]; then
+			tar -cC "$(dirname "$src")" "$(basename "$src")" | tar -xC "$(dirname "$target")"
+		fi
+	done
+fi
+
+exec "$@"

--- a/6-rc/debian/Dockerfile
+++ b/6-rc/debian/Dockerfile
@@ -1,0 +1,128 @@
+# https://docs.ghost.org/faq/node-versions/
+# https://github.com/nodejs/Release (looking for "LTS")
+FROM node:22-bookworm-slim
+
+# grab gosu for easy step-down from root
+# https://github.com/tianon/gosu/releases
+ENV GOSU_VERSION 1.17
+RUN set -eux; \
+# save list of currently installed packages for later so we can clean up
+	savedAptMark="$(apt-mark showmanual)"; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends ca-certificates gnupg wget; \
+	rm -rf /var/lib/apt/lists/*; \
+	\
+	dpkgArch="$(dpkg --print-architecture | awk -F- '{ print $NF }')"; \
+	wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch"; \
+	wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch.asc"; \
+	\
+# verify the signature
+	export GNUPGHOME="$(mktemp -d)"; \
+	gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4; \
+	gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu; \
+	gpgconf --kill all; \
+	rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc; \
+	\
+# clean up fetch dependencies
+	apt-mark auto '.*' > /dev/null; \
+	[ -z "$savedAptMark" ] || apt-mark manual $savedAptMark > /dev/null; \
+	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
+	\
+	chmod +x /usr/local/bin/gosu; \
+# verify that the binary works
+	gosu --version; \
+	gosu nobody true
+
+ENV NODE_ENV production
+
+ENV GHOST_CLI_VERSION 1.27.1
+RUN set -eux; \
+	npm install -g "ghost-cli@$GHOST_CLI_VERSION"; \
+	npm cache clean --force
+
+ENV GHOST_INSTALL /var/lib/ghost
+ENV GHOST_CONTENT /var/lib/ghost/content
+
+ENV GHOST_VERSION 6.0.0-alpha.1
+
+RUN set -eux; \
+	mkdir -p "$GHOST_INSTALL"; \
+	chown node:node "$GHOST_INSTALL"; \
+	\
+	savedAptMark="$(apt-mark showmanual)"; \
+	aptPurge=; \
+	\
+	installCmd='gosu node ghost install "$GHOST_VERSION" --db mysql --dbhost mysql --no-prompt --no-stack --no-setup --dir "$GHOST_INSTALL"'; \
+	case "$GHOST_VERSION" in *-alpha* | *-beta* | *-rc*) installCmd="$installCmd --channel next" ;; esac; \
+	if ! eval "$installCmd"; then \
+		aptPurge=1; \
+		apt-get update; \
+		apt-get install -y --no-install-recommends g++ make python3; \
+		eval "$installCmd"; \
+	fi; \
+	\
+# Tell Ghost to listen on all ips and not prompt for additional configuration
+	cd "$GHOST_INSTALL"; \
+	gosu node ghost config --no-prompt --ip '::' --port 2368 --url 'http://localhost:2368'; \
+	gosu node ghost config paths.contentPath "$GHOST_CONTENT"; \
+	\
+# make a config.json symlink for NODE_ENV=development (and sanity check that it's correct)
+	gosu node ln -s config.production.json "$GHOST_INSTALL/config.development.json"; \
+	readlink -f "$GHOST_INSTALL/config.development.json"; \
+	\
+# need to save initial content for pre-seeding empty volumes
+	mv "$GHOST_CONTENT" "$GHOST_INSTALL/content.orig"; \
+	mkdir -p "$GHOST_CONTENT"; \
+	chown node:node "$GHOST_CONTENT"; \
+	chmod 1777 "$GHOST_CONTENT"; \
+	\
+# force install a few extra packages manually since they're "optional" dependencies
+# (which means that if it fails to install, like on ARM/ppc64le/s390x, the failure will be silently ignored and thus turn into a runtime error instead)
+# see https://github.com/TryGhost/Ghost/pull/7677 for more details
+	cd "$GHOST_INSTALL/current"; \
+# scrape the expected versions directly from Ghost/dependencies
+	packages="$(node -p ' \
+		var ghost = require("./package.json"); \
+		var transform = require("./node_modules/@tryghost/image-transform/package.json"); \
+		[ \
+			"sharp@" + transform.optionalDependencies["sharp"], \
+			"sqlite3@" + ghost.optionalDependencies["sqlite3"], \
+		].join(" ") \
+	')"; \
+	if echo "$packages" | grep 'undefined'; then exit 1; fi; \
+	for package in $packages; do \
+		installCmd='gosu node yarn add "$package" --force'; \
+		if ! eval "$installCmd"; then \
+# must be some non-amd64 architecture pre-built binaries aren't published for, so let's install some build deps and do-it-all-over-again
+			aptPurge=1; \
+			apt-get update; \
+			apt-get install -y --no-install-recommends g++ make python3; \
+			case "$package" in \
+				# TODO sharp@*) apt-get install -y --no-install-recommends libvips-dev ;; \
+				sharp@*) echo >&2 "sorry: libvips 8.10 in Debian bullseye is not new enough (8.12.2+) for sharp 0.30 😞"; continue ;; \
+			esac; \
+			\
+			eval "$installCmd --build-from-source"; \
+		fi; \
+	done; \
+	\
+	if [ -n "$aptPurge" ]; then \
+		apt-mark showmanual | xargs apt-mark auto > /dev/null; \
+		[ -z "$savedAptMark" ] || apt-mark manual $savedAptMark; \
+		apt-get purge -y --auto-remove; \
+		rm -rf /var/lib/apt/lists/*; \
+	fi; \
+	\
+	gosu node yarn cache clean; \
+	gosu node npm cache clean --force; \
+	npm cache clean --force; \
+	rm -rv /tmp/yarn* /tmp/v8*
+
+WORKDIR $GHOST_INSTALL
+VOLUME $GHOST_CONTENT
+
+COPY docker-entrypoint.sh /usr/local/bin
+ENTRYPOINT ["docker-entrypoint.sh"]
+
+EXPOSE 2368
+CMD ["node", "current/index.js"]

--- a/6-rc/debian/docker-entrypoint.sh
+++ b/6-rc/debian/docker-entrypoint.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+set -e
+
+# allow the container to be started with `--user`
+if [[ "$*" == node*current/index.js* ]] && [ "$(id -u)" = '0' ]; then
+	find "$GHOST_CONTENT" \! -user node -exec chown node '{}' +
+	exec gosu node "$BASH_SOURCE" "$@"
+fi
+
+if [[ "$*" == node*current/index.js* ]]; then
+	baseDir="$GHOST_INSTALL/content.orig"
+	for src in "$baseDir"/*/ "$baseDir"/themes/*; do
+		src="${src%/}"
+		target="$GHOST_CONTENT/${src#$baseDir/}"
+		mkdir -p "$(dirname "$target")"
+		if [ ! -e "$target" ]; then
+			tar -cC "$(dirname "$src")" "$(basename "$src")" | tar -xC "$(dirname "$target")"
+		fi
+	done
+fi
+
+exec "$@"


### PR DESCRIPTION
Here's a tag diff against https://github.com/docker-library/official-images/pull/19482 (so it doesn't include those changes and is easier to see the 6.x impact):

```diff
$ diff -u <(bashbrew cat https://github.com/docker-library/official-images/raw/8024ba96538fd9093b4f612676460174fc8bedbe/library/ghost) <(bashbrew cat <(./generate-stackbrew-library.sh))
--- /dev/fd/63	2025-07-17 09:54:49.219661496 -0700
+++ /dev/fd/62	2025-07-17 09:54:49.219661496 -0700
@@ -1,6 +1,16 @@
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon), Joseph Ferguson <yosifkit@gmail.com> (@yosifkit), Austin Burdine <austin@acburdine.me> (@acburdine)
 GitRepo: https://github.com/docker-library/ghost.git
 
+Tags: 6.0.0-alpha.1, 6.0.0-alpha, 6.0.0, 6.0, 6-rc
+Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
+GitCommit: 83ce6d8beb81974a32d4b1461406ab4a3e8be365
+Directory: 6-rc/debian
+
+Tags: 6.0.0-alpha.1-alpine, 6.0.0-alpha-alpine, 6.0.0-alpine, 6.0-alpine, 6-rc-alpine
+Architectures: amd64, arm32v6, arm32v7, arm64v8
+GitCommit: 83ce6d8beb81974a32d4b1461406ab4a3e8be365
+Directory: 6-rc/alpine
+
 Tags: 5.130.0, 5.130, 5, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
 GitCommit: 61f69f51ecdcf0140896197ebfd10c58f3a27257
```