### PR TITLE
Update pre-releases to only have their full explicit version alias, not all the variants like "6.0"

### DIFF
--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -72,18 +72,22 @@ join() {
 }
 
 for version in "${versions[@]}"; do
+	rcVersion="${version%-rc}"
+
 	for variant in debian alpine; do
 		commit="$(dirCommit "$version/$variant")"
 
 		fullVersion="$(git show "$commit":"$version/$variant/Dockerfile" | awk '$1 == "ENV" && $2 == "GHOST_VERSION" { print $3; exit }')"
 
 		versionAliases=()
-		while [ "$fullVersion" != "$version" -a "${fullVersion%[.-]*}" != "$fullVersion" ]; do
-			versionAliases+=( $fullVersion )
-			fullVersion="${fullVersion%[.-]*}"
-		done
+		if [ "$version" = "$rcVersion" ]; then
+			while [ "$fullVersion" != "$version" -a "${fullVersion%[.-]*}" != "$fullVersion" ]; do
+				versionAliases+=( $fullVersion )
+				fullVersion="${fullVersion%[.-]*}"
+			done
+		fi
 		versionAliases+=(
-			$version
+			$fullVersion
 			${aliases[$version]:-}
 		)
 


### PR DESCRIPTION
https://github.com/docker-library/official-images/pull/19482#discussion_r2216532870

```diff
$ diff -u <(bashbrew cat https://github.com/docker-library/official-images/raw/3dd86fb/library/ghost) <(bashbrew cat <(./generate-stackbrew-library.sh))
--- /dev/fd/63	2025-07-18 11:25:18.205937853 -0700
+++ /dev/fd/62	2025-07-18 11:25:18.205937853 -0700
@@ -1,12 +1,12 @@
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon), Joseph Ferguson <yosifkit@gmail.com> (@yosifkit), Austin Burdine <austin@acburdine.me> (@acburdine)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 6.0.0-alpha.1, 6.0.0-alpha, 6.0.0, 6.0, 6-rc
+Tags: 6.0.0-alpha.1
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
 GitCommit: 83ce6d8beb81974a32d4b1461406ab4a3e8be365
 Directory: 6-rc/debian
 
-Tags: 6.0.0-alpha.1-alpine, 6.0.0-alpha-alpine, 6.0.0-alpine, 6.0-alpine, 6-rc-alpine
+Tags: 6.0.0-alpha.1-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8
 GitCommit: 83ce6d8beb81974a32d4b1461406ab4a3e8be365
 Directory: 6-rc/alpine
```

cc @acburdine (@ErisDS) :heart: