### PR TITLE
Add fontconfig to prevent crashing

### DIFF
--- a/5/alpine3.22/Dockerfile
+++ b/5/alpine3.22/Dockerfile
@@ -8,7 +8,10 @@ FROM node:20-alpine3.22
 
 RUN apk add --no-cache \
 # add "bash" for "[["
-		bash
+		bash \
+# install fontconfig for sharp
+# https://github.com/lovell/sharp/blob/v0.34.2/docs/src/content/docs/install.md#fonts
+		fontconfig
 
 # grab gosu for easy step-down from root
 # https://github.com/tianon/gosu/releases

--- a/5/bookworm/Dockerfile
+++ b/5/bookworm/Dockerfile
@@ -6,6 +6,15 @@
 
 FROM node:20-bookworm-slim
 
+RUN set -eux; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
+# install fontconfig for sharp
+# https://github.com/lovell/sharp/blob/v0.34.2/docs/src/content/docs/install.md#fonts
+		fontconfig \
+	; \
+	rm -rf /var/lib/apt/lists/*
+
 # grab gosu for easy step-down from root
 # https://github.com/tianon/gosu/releases
 ENV GOSU_VERSION 1.19

--- a/6/alpine3.22/Dockerfile
+++ b/6/alpine3.22/Dockerfile
@@ -8,7 +8,10 @@ FROM node:22-alpine3.22
 
 RUN apk add --no-cache \
 # add "bash" for "[["
-		bash
+		bash \
+# install fontconfig for sharp
+# https://github.com/lovell/sharp/blob/v0.34.2/docs/src/content/docs/install.md#fonts
+		fontconfig
 
 # grab gosu for easy step-down from root
 # https://github.com/tianon/gosu/releases

--- a/6/bookworm/Dockerfile
+++ b/6/bookworm/Dockerfile
@@ -6,6 +6,15 @@
 
 FROM node:22-bookworm-slim
 
+RUN set -eux; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
+# install fontconfig for sharp
+# https://github.com/lovell/sharp/blob/v0.34.2/docs/src/content/docs/install.md#fonts
+		fontconfig \
+	; \
+	rm -rf /var/lib/apt/lists/*
+
 # grab gosu for easy step-down from root
 # https://github.com/tianon/gosu/releases
 ENV GOSU_VERSION 1.19

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -13,9 +13,21 @@ FROM {{ .variants[env.variant].from }}
 {{ if is_alpine then ( -}}
 RUN apk add --no-cache \
 # add "bash" for "[["
-		bash
+		bash \
+# install fontconfig for sharp
+# https://github.com/lovell/sharp/blob/v0.34.2/docs/src/content/docs/install.md#fonts
+		fontconfig
+{{ ) else ( -}}
+RUN set -eux; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
+# install fontconfig for sharp
+# https://github.com/lovell/sharp/blob/v0.34.2/docs/src/content/docs/install.md#fonts
+		fontconfig \
+	; \
+	{{ clean_apt }}
+{{ ) end -}}
 
-{{ ) else  "" end -}}
 # grab gosu for easy step-down from root
 # https://github.com/tianon/gosu/releases
 ENV GOSU_VERSION 1.19


### PR DESCRIPTION
Sharp `v0.34.2` is the version used by Ghost [v5](https://github.com/TryGhost/Ghost/blob/v5.130.5/yarn.lock#L29335) and [v6](https://github.com/TryGhost/Ghost/blob/v6.3.1/yarn.lock#L30187), hence the version in the link.

Fixes https://github.com/docker-library/ghost/issues/453