### PR TITLE
Update GHOST_CLI_VERSION to 1.28.4

### DIFF
--- a/6/alpine3.23/Dockerfile
+++ b/6/alpine3.23/Dockerfile
@@ -42,7 +42,7 @@ RUN set -eux; \
 
 ENV NODE_ENV production
 
-ENV GHOST_CLI_VERSION 1.28.3
+ENV GHOST_CLI_VERSION 1.28.4
 RUN set -eux; \
 	npm install -g "ghost-cli@$GHOST_CLI_VERSION"; \
 	npm cache clean --force


### PR DESCRIPTION
ref https://github.com/TryGhost/Ghost-CLI/pull/2029

Latest Ghost-CLI version has an update to the `myqsl2` dependency to resolve some vulnerability warnings that can show up for the docker image.