### PR TITLE
Add repo-local bashbrew setup action

### DIFF
--- a/.github/actions/bashbrew/action.yml
+++ b/.github/actions/bashbrew/action.yml
@@ -1,0 +1,22 @@
+# note: this is a slightly modified version of the action script in https://github.com/docker-library/bashbrew/blob/master/action.yml
+# modified to pin the setup-go action to a commit sha per the TryGhost org Github Action policies.
+name: 'Install Bashbrew'
+description: 'Install the "bashbrew" tool in GITHUB_PATH'
+runs:
+  using: 'composite'
+  steps:
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      with:
+        repository: docker-library/bashbrew
+        path: ${{ github.action_path }}
+        ref: d662ff01570964b5f648df009c9269f388285692 # HEAD
+        persist-credentials: false
+    - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+      with:
+        go-version-file: '${{ github.action_path }}/go.mod'
+    - run: |
+        '${{ github.action_path }}/bashbrew.sh' --version > /dev/null
+        '${{ github.action_path }}/bin/bashbrew' --version
+        echo '${{ github.action_path }}/bin' >> "$GITHUB_PATH"
+        echo 'BASHBREW_SCRIPTS=${{ github.action_path }}/scripts' >> "$GITHUB_ENV"
+      shell: 'bash -Eeuo pipefail -x {0}'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,8 @@ name: GitHub CI
 on:
   pull_request:
   push:
+    branches:
+      - master
   schedule:
     - cron: 0 0 * * 0
 
@@ -11,7 +13,6 @@ defaults:
     shell: 'bash -Eeuo pipefail -x {0}'
 
 jobs:
-
   generate-jobs:
     name: Generate Jobs
     runs-on: ubuntu-latest
@@ -19,7 +20,8 @@ jobs:
       strategy: ${{ steps.generate-jobs.outputs.strategy }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
-      - uses: docker-library/bashbrew@d662ff01570964b5f648df009c9269f388285692 # HEAD
+      # - uses: docker-library/bashbrew@d662ff01570964b5f648df009c9269f388285692 # HEAD
+      - uses: ./.github/actions/bashbrew/
       - id: generate-jobs
         name: Generate Jobs
         run: |
@@ -33,7 +35,7 @@ jobs:
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Prepare Environment
         run: ${{ matrix.runs.prepare }}
       - name: Pull Dependencies

--- a/.github/workflows/verify-templating.yml
+++ b/.github/workflows/verify-templating.yml
@@ -3,6 +3,8 @@ name: Verify Templating
 on:
   pull_request:
   push:
+    branches:
+      - master
   workflow_dispatch:
 
 defaults:


### PR DESCRIPTION
the TryGhost org requires pinned commit shas for all actions. The current docker-library/bashbrew action doesn't pin the setup-go action, so this PR creates a repo-local action for installing bashbrew.