### PR TITLE
Fix optional dependency check for better-sqlite3

### DIFF
--- a/6/alpine3.23/Dockerfile
+++ b/6/alpine3.23/Dockerfile
@@ -84,7 +84,7 @@ RUN set -eux; \
 	\
 	# test that the optional dependencies are installed and loadable
 	cd current; \
-	gosu node node -e 'require("sqlite3"); if (!require("@tryghost/image-transform").canTransformFiles()) throw new Error("sharp not installed");'
+	gosu node node -e 'require("better-sqlite3"); if (!require("@tryghost/image-transform").canTransformFiles()) throw new Error("sharp not installed");'
 
 WORKDIR $GHOST_INSTALL
 VOLUME $GHOST_CONTENT

--- a/6/bookworm/Dockerfile
+++ b/6/bookworm/Dockerfile
@@ -86,7 +86,7 @@ RUN set -eux; \
 	\
 	# test that the optional dependencies are installed and loadable
 	cd current; \
-	gosu node node -e 'require("sqlite3"); if (!require("@tryghost/image-transform").canTransformFiles()) throw new Error("sharp not installed");'
+	gosu node node -e 'require("better-sqlite3"); if (!require("@tryghost/image-transform").canTransformFiles()) throw new Error("sharp not installed");'
 
 WORKDIR $GHOST_INSTALL
 VOLUME $GHOST_CONTENT

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -117,7 +117,7 @@ RUN set -eux; \
 	\
 	# test that the optional dependencies are installed and loadable
 	cd current; \
-	gosu node node -e 'require("sqlite3"); if (!require("@tryghost/image-transform").canTransformFiles()) throw new Error("sharp not installed");'
+	gosu node node -e 'require("better-sqlite3"); if (!require("@tryghost/image-transform").canTransformFiles()) throw new Error("sharp not installed");'
 
 WORKDIR $GHOST_INSTALL
 VOLUME $GHOST_CONTENT


### PR DESCRIPTION
once the next version of Ghost is released, this'll need to be merged in order to fix the optional dep assertion (next version of Ghost will use better-sqlite3 instead of sqlite3)